### PR TITLE
Top nodes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ that [clang compiler](http://clang.llvm.org/) has:
 * [clang 3.4 warnings](warnings-clang-3.4.txt)
 * [clang 3.5 warnings](warnings-clang-3.5.txt)
 * [clang 3.6 warnings](warnings-clang-3.6.txt)
+* [clang 3.7 warnings](warnings-clang-3.7.txt)
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,13 @@ After you have installed all the requirements and are able to run
 ANTLR with `antlr4` command, just use following commands:
 
     make
-    ./parse-clang-diagnostic-groups.py <path-to-clang-source>/include/clang/Basic/DiagnosticGroups.td
+    ./parse-clang-diagnostic-groups.py <path-to-clang-source>/include/clang/Basic/DiagnosticGroups.td [--show-class]
 
 And you'll get the list of all individual warning flags and their
 dependencies that are in the requested clang version.
 
+Using the --show-class flag displays the diagnostic class name next to the
+diagnostic switch flag name, which is useful for seeing which flags have no
+associated class name ("None") and thus have no effect in themselves (though
+their children may). Such flags may exist to have command line compatibility
+with GCC.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ After you have installed all the requirements and are able to run
 ANTLR with `antlr4` command, just use following commands:
 
     make
-    ./parse-clang-diagnostic-groups.py <path-to-clang-source>/include/clang/Basic/DiagnosticGroups.td [--show-class]
+    ./parse-clang-diagnostic-groups.py <path-to-clang-source>/include/clang/Basic/DiagnosticGroups.td [--top-nodes-only] [--show-class]
 
 And you'll get the list of all individual warning flags and their
 dependencies that are in the requested clang version.
+
+Using the --top-nodes-only flag will only show top level nodes that have no
+parent node. In other words it cuts out the duplication of the nested
+diagnostic nodes and makes the list shorter. For example, a diagnostic indented
+to the third level would normally be displayed three times in the full list,
+and a top level/first level diagnostic would be displayed just once.
 
 Using the --show-class flag displays the diagnostic class name next to the
 diagnostic switch flag name, which is useful for seeing which flags have no

--- a/parse-clang-diagnostic-groups.py
+++ b/parse-clang-diagnostic-groups.py
@@ -51,10 +51,13 @@ class ClangDiagnosticGroupsListener(TableGenListener.TableGenListener):
     def exitClassDefinition(self, ctx):
         if self.currentClassDefinitionName == "DiagGroup":
             if self.currentSwitchName is not None:
-                self.switchNames[self.currentSwitchName] = self.currentDefinitionName
-                self.switchClassesReferences[self.currentSwitchName] = self.currentReferences
+                self.switchNames[self.currentSwitchName] = \
+                    self.currentDefinitionName
+                self.switchClassesReferences[self.currentSwitchName] = \
+                    self.currentReferences
             if self.currentDefinitionName:
-                self.switchClasses[self.currentDefinitionName] = self.currentSwitchName
+                self.switchClasses[self.currentDefinitionName] = \
+                    self.currentSwitchName
         self.currentSwitchName = None
         self.currentClassDefinitionName = None
         self.currentReferences = None

--- a/parse-clang-diagnostic-groups.py
+++ b/parse-clang-diagnostic-groups.py
@@ -7,10 +7,13 @@ import TableGenListener
 import TableGenParser
 
 show_class_name = False
+top_nodes_only = False
 
 for arg in sys.argv:
     if arg == "--show-class":
         show_class_name = True
+    elif arg == "--top-nodes-only":
+        top_nodes_only = True
     else:
         filename = arg
 
@@ -89,9 +92,19 @@ def print_references(diagnostics, switch_name, level):
         print "# {0:50} {1}".format(switch_string, class_name)
         print_references(diagnostics, reference_switch_name, level + 1)
 
+def is_root_node(diagnostics, switch_name):
+    for this_name in sorted(diagnostics.switchNames.keys()):
+        references = diagnostics.switchClassesReferences.get(this_name, [])
+        for reference_class_name in references:
+            reference_switch_name = \
+                diagnostics.switchClasses[reference_class_name]
+            if switch_name == reference_switch_name:
+                return False
+    return True
+
 for name in sorted(diagnostics.switchNames.keys()):
-    class_name = \
-        class_name_string(diagnostics.switchNames[name])
-    print "-W{0:50} {1}".format (name, class_name)
-    print_references(diagnostics, name, 1)
+    if not top_nodes_only or is_root_node(diagnostics, name):
+        class_name = class_name_string(diagnostics.switchNames[name])
+        print "-W{0:50} {1}".format (name, class_name)
+        print_references(diagnostics, name, 1)
 

--- a/parse-clang-diagnostic-groups.py
+++ b/parse-clang-diagnostic-groups.py
@@ -6,7 +6,15 @@ import TableGenLexer
 import TableGenListener
 import TableGenParser
 
-string_input = FileStream(sys.argv[1])
+show_class_name = False
+
+for arg in sys.argv:
+    if arg == "--show-class":
+        show_class_name = True
+    else:
+        filename = arg
+
+string_input = FileStream(filename)
 lexer = TableGenLexer.TableGenLexer(string_input)
 stream = CommonTokenStream(lexer)
 parser = TableGenParser.TableGenParser(stream)
@@ -62,6 +70,12 @@ walker = ParseTreeWalker()
 walker.walk(diagnostics, tree)
 
 
+def class_name_string(class_name):
+    string = ""
+    if show_class_name:
+        string = class_name or " <<<NONE>>>"
+    return string
+
 def print_references(diagnostics, switch_name, level):
     references = diagnostics.switchClassesReferences.get(switch_name, [])
     reference_switches = []
@@ -69,10 +83,15 @@ def print_references(diagnostics, switch_name, level):
         reference_switch_name = diagnostics.switchClasses[reference_class_name]
         reference_switches.append(reference_switch_name)
     for reference_switch_name in sorted(reference_switches):
-        print "# %s-W%s" % ("  " * level, reference_switch_name)
+        class_name = \
+            class_name_string(diagnostics.switchNames[reference_switch_name])
+        switch_string = "%s-W%s" % ("  " * level, reference_switch_name)
+        print "# {0:50} {1}".format(switch_string, class_name)
         print_references(diagnostics, reference_switch_name, level + 1)
 
-
 for name in sorted(diagnostics.switchNames.keys()):
-    print "-W%s" % name
+    class_name = \
+        class_name_string(diagnostics.switchNames[name])
+    print "-W{0:50} {1}".format (name, class_name)
     print_references(diagnostics, name, 1)
+

--- a/warnings-toplevelonly-clang-3.2.txt
+++ b/warnings-toplevelonly-clang-3.2.txt
@@ -1,0 +1,292 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Wint-to-pointer-cast                          IntToPointerCast
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-value                               UnusedValue
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-abi                                             <<<NONE>>>
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-compat-bind-to-temporary-copy          CXX98CompatBindToTemporaryCopy
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+-Wc11-extensions                                     C11
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                           <<<NONE>>>
+-Wchar-align                                          <<<NONE>>>
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wdefault-arg-special-member                         DefaultArgSpecialMember
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#     -Wformat-security                              FormatSecurity
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wvla                                            VLA
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wignored-attributes                                 IgnoredAttributes
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimport                                              <<<NONE>>>
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+-Wincomplete-umbrella                                IncompleteUmbrella
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlambda-extensions                                  LambdaExtensions
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmodule-build                                       ModuleBuild
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wold-style-cast                                      <<<NONE>>>
+-Wold-style-definition                                <<<NONE>>>
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wprotocol                                           Protocol
+-Wreadonly-setter-attrs                              ReadOnlySetterAttrs
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wredundant-decls                                     <<<NONE>>>
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wsection                                            Section
+-Wselector                                           Selector
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wstack-protector                                     <<<NONE>>>
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wundeclared-selector                                UndeclaredSelector
+-Wunicode                                            Unicode
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr

--- a/warnings-toplevelonly-clang-3.3.txt
+++ b/warnings-toplevelonly-clang-3.3.txt
@@ -1,0 +1,336 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wsizeof-array-decay                           SizeofArrayDecay
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#       -Wstatic-self-init                           UninitializedStaticSelfInit
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-value                               UnusedValue
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Woverloaded-shift-op-parentheses              OverloadedShiftOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-abi                                             <<<NONE>>>
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Warray-bounds                                       ArrayBounds
+-Warray-bounds-pointer-arithmetic                    ArrayBoundsPointerArithmetic
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbad-array-new-length                               BadArrayNewLength
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+-Wbuiltin-macro-redefined                            BuiltinMacroRedefined
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+#     -Wcxx98-cxx11-compat                           CXXPre1yCompat
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++11-compat-pedantic                              CXX11CompatPedantic
+#   -Wcxx98-cxx11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wcxx98-cxx11-compat                           CXXPre1yCompat
+-Wc++1y-extensions                                   CXX1y
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-compat-bind-to-temporary-copy          CXX98CompatBindToTemporaryCopy
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+#     -Wcxx98-cxx11-compat                           CXXPre1yCompat
+#   -Wcxx98-cxx11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wcxx98-cxx11-compat                           CXXPre1yCompat
+-Wc11-extensions                                     C11
+-Wc99-compat                                         C99Compat
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                           <<<NONE>>>
+-Wchar-align                                          <<<NONE>>>
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconfig-macros                                      ConfigMacros
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wdangling-field                                     DanglingField
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdeprecated-objc-isa-usage                          DeprecatedObjCIsaUsage
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdistributed-object-modifiers                       DistributedObjectModifiers
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+#   -Wdocumentation-unknown-command                  DocumentationUnknownCommand
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#     -Wformat-security                              FormatSecurity
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+#   -Wvla-extension                                  VLAExtension
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wignored-attributes                                 IgnoredAttributes
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimport                                              <<<NONE>>>
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+#   -Wincompatible-pointer-types-discards-qualifiers IncompatiblePointerTypesDiscardsQualifiers
+-Wincomplete-umbrella                                IncompleteUmbrella
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Wint-to-pointer-cast                                IntToPointerCast
+-Winvalid-noreturn                                   InvalidNoreturn
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Winvalid-source-encoding                            InvalidSourceEncoding
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmethod-signatures                                  MethodSignatures
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmissing-noreturn                                   MissingNoreturn
+-Wmodule-conflict                                    ModuleConflict
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#       -Wbitfield-constant-conversion               BitFieldConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-pod-varargs                                    NonPODVarargs
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-arithmetic                                    NullArithmetic
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-property-synthesis                            ObjCNoPropertyAutoSynthesis
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wold-style-cast                                      <<<NONE>>>
+-Wold-style-definition                                <<<NONE>>>
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wprotocol                                           Protocol
+-Wreadonly-setter-attrs                              ReadOnlySetterAttrs
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wredundant-decls                                     <<<NONE>>>
+-Wreinterpret-base-class                             ReinterpretBaseClass
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wreturn-stack-address                               ReturnStackAddress
+-Wsection                                            Section
+-Wselector                                           Selector
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+#   -Wunsequenced                                    Unsequenced
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wsizeof-pointer-memaccess                           SizeofPointerMemaccess
+-Wsource-uses-openmp                                 SourceUsesOpenMP
+-Wstack-protector                                     <<<NONE>>>
+-Wstatic-float-init                                  StaticFloatInit
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+-Wstatic-in-inline                                   StaticInInline
+-Wstatic-local-in-inline                             StaticLocalInInline
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+-Wthread-safety-beta                                 ThreadSafetyBeta
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wundeclared-selector                                UndeclaredSelector
+-Wundefined-reinterpret-cast                         UndefinedReinterpretCast
+-Wunicode                                            Unicode
+-Wunknown-warning-option                             UnknownWarningOption
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunused-command-line-argument                       UnusedCommandLineArgument
+#   -Wunused-sanitize-argument                       UnusedSanitizeArgument
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wvla                                                VLA
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr

--- a/warnings-toplevelonly-clang-3.4.txt
+++ b/warnings-toplevelonly-clang-3.4.txt
@@ -1,0 +1,383 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wextern-c-compat                              ExternCCompat
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wsizeof-array-decay                           SizeofArrayDecay
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#       -Wstatic-self-init                           UninitializedStaticSelfInit
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-property-ivar                       UnusedPropertyIvar
+#       -Wunused-value                               UnusedValue
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#         -Wunused-const-variable                    UnusedConstVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-not-parentheses                      LogicalNotParentheses
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Woverloaded-shift-op-parentheses              OverloadedShiftOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-abi                                             <<<NONE>>>
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Warray-bounds                                       ArrayBounds
+-Warray-bounds-pointer-arithmetic                    ArrayBoundsPointerArithmetic
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbad-array-new-length                               BadArrayNewLength
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+-Wbridge-cast                                        ObjCBridge
+-Wbuiltin-macro-redefined                            BuiltinMacroRedefined
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++11-compat-pedantic                              CXX11CompatPedantic
+#   -Wc++98-c++11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+-Wc++1y-extensions                                   CXX1y
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-c++11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+#     -Wc++98-compat-bind-to-temporary-copy          CXX98CompatBindToTemporaryCopy
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+-Wc11-extensions                                     C11
+-Wc99-compat                                         C99Compat
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                           <<<NONE>>>
+-Wchar-align                                          <<<NONE>>>
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconfig-macros                                      ConfigMacros
+-Wconsumed                                           Consumed
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wdangling-field                                     DanglingField
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+#   -Wdeprecated-increment-bool                      DeprecatedIncrementBool
+#   -Wdeprecated-register                            DeprecatedRegister
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdeprecated-objc-isa-usage                          DeprecatedObjCIsaUsage
+-Wdeprecated-objc-pointer-introspection              ObjCPointerIntrospect
+#   -Wdeprecated-objc-pointer-introspection-performSelector ObjCPointerIntrospectPerformSelector
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdistributed-object-modifiers                       DistributedObjectModifiers
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+#   -Wdocumentation-unknown-command                  DocumentationUnknownCommand
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#     -Wformat-security                              FormatSecurity
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-alignof-expression                         GNUAlignofExpression
+#   -Wgnu-anonymous-struct                           GNUAnonymousStruct
+#   -Wgnu-binary-literal                             GNUBinaryLiteral
+#   -Wgnu-case-range                                 GNUCaseRange
+#   -Wgnu-complex-integer                            GNUComplexInteger
+#   -Wgnu-compound-literal-initializer               GNUCompoundLiteralInitializer
+#   -Wgnu-conditional-omitted-operand                GNUConditionalOmittedOperand
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wgnu-empty-initializer                          GNUEmptyInitializer
+#   -Wgnu-empty-struct                               GNUEmptyStruct
+#   -Wgnu-flexible-array-initializer                 GNUFlexibleArrayInitializer
+#   -Wgnu-flexible-array-union-member                GNUFlexibleArrayUnionMember
+#   -Wgnu-folding-constant                           GNUFoldingConstant
+#   -Wgnu-imaginary-constant                         GNUImaginaryConstant
+#   -Wgnu-label-as-value                             GNULabelsAsValue
+#   -Wgnu-redeclared-enum                            GNURedeclaredEnum
+#   -Wgnu-statement-expression                       GNUStatementExpression
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+#   -Wgnu-string-literal-operator-template           GNUStringLiteralOperatorTemplate
+#   -Wgnu-union-cast                                 GNUUnionCast
+#   -Wgnu-variable-sized-type-not-at-end             GNUVariableSizedTypeNotAtEnd
+#   -Wgnu-zero-line-directive                        GNUZeroLineDirective
+#   -Wgnu-zero-variadic-macro-arguments              GNUZeroVariadicMacroArguments
+#   -Wredeclared-class-member                        RedeclaredClassMember
+#   -Wvla-extension                                  VLAExtension
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wignored-attributes                                 IgnoredAttributes
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimport                                              <<<NONE>>>
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+#   -Wincompatible-pointer-types-discards-qualifiers IncompatiblePointerTypesDiscardsQualifiers
+-Wincomplete-module                                  IncompleteModule
+#   -Wincomplete-umbrella                            IncompleteUmbrella
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Wint-to-pointer-cast                                IntToPointerCast
+#   -Wint-to-void-pointer-cast                       IntToVoidPointerCast
+-Winvalid-command-line-argument                      InvalidCommandLineArgument
+-Winvalid-iboutlet                                   ObjCInvalidIBOutletProperty
+-Winvalid-noreturn                                   InvalidNoreturn
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Winvalid-source-encoding                            InvalidSourceEncoding
+-Wkeyword-compat                                     KeywordCompat
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wloop-analysis                                      LoopAnalysis
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmethod-signatures                                  MethodSignatures
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmissing-noreturn                                   MissingNoreturn
+-Wmodule-conflict                                    ModuleConflict
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnewline-eof                                        NewlineEOF
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#       -Wbitfield-constant-conversion               BitFieldConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-pod-varargs                                    NonPODVarargs
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-arithmetic                                    NullArithmetic
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-literal-missing-atsign                        ObjCLiteralMissingAtSign
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-property-synthesis                            ObjCNoPropertyAutoSynthesis
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wobjc-string-concatenation                          ObjCStringConcatenation
+-Wold-style-cast                                      <<<NONE>>>
+-Wold-style-definition                                <<<NONE>>>
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wprotocol                                           Protocol
+-Wreadonly-setter-attrs                              ReadOnlySetterAttrs
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wredundant-decls                                     <<<NONE>>>
+-Wreinterpret-base-class                             ReinterpretBaseClass
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wreturn-stack-address                               ReturnStackAddress
+-Wsection                                            Section
+-Wselector                                           Selector
+#   -Wselector-type-mismatch                         SelectorTypeMismatch
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+#   -Wunsequenced                                    Unsequenced
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wsizeof-pointer-memaccess                           SizeofPointerMemaccess
+-Wsource-uses-openmp                                 SourceUsesOpenMP
+-Wstack-protector                                     <<<NONE>>>
+-Wstatic-float-init                                  StaticFloatInit
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+-Wstatic-in-inline                                   StaticInInline
+-Wstatic-local-in-inline                             StaticLocalInInline
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstring-plus-char                                   StringPlusChar
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+-Wthread-safety-beta                                 ThreadSafetyBeta
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wundeclared-selector                                UndeclaredSelector
+-Wundefined-reinterpret-cast                         UndefinedReinterpretCast
+-Wunicode                                            Unicode
+-Wunknown-warning-option                             UnknownWarningOption
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunsupported-friend                                 UnsupportedFriend
+-Wunused-command-line-argument                       UnusedCommandLineArgument
+#   -Wunused-sanitize-argument                       UnusedSanitizeArgument
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvarargs                                            Varargs
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wvla                                                VLA
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr

--- a/warnings-toplevelonly-clang-3.5.txt
+++ b/warnings-toplevelonly-clang-3.5.txt
@@ -1,0 +1,443 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabsolute-value                                     AbsoluteValue
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+#   -Wpointer-bool-conversion                        PointerBoolConversion
+#   -Wstring-compare                                 StringCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wextern-c-compat                              ExternCCompat
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-designated-initializers                 ObjCDesignatedInit
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wsizeof-array-decay                           SizeofArrayDecay
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#       -Wstatic-self-init                           UninitializedStaticSelfInit
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-property-ivar                       UnusedPropertyIvar
+#       -Wunused-value                               UnusedValue
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#         -Wunused-const-variable                    UnusedConstVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-not-parentheses                      LogicalNotParentheses
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Woverloaded-shift-op-parentheses              OverloadedShiftOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+#   -Wswitch-bool                                    SwitchBool
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-abi                                             <<<NONE>>>
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Warray-bounds                                       ArrayBounds
+-Warray-bounds-pointer-arithmetic                    ArrayBoundsPointerArithmetic
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         Attributes
+#   -Wignored-attributes                             IgnoredAttributes
+#   -Wunknown-attributes                             UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbackend-plugin                                     BackendPlugin
+-Wbad-array-new-length                               BadArrayNewLength
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+#     -Wpointer-bool-conversion                      PointerBoolConversion
+#     -Wundefined-bool-conversion                    UndefinedBoolConversion
+-Wbridge-cast                                        ObjCBridge
+-Wbuiltin-macro-redefined                            BuiltinMacroRedefined
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++11-compat-pedantic                              CXX11CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+-Wc++14-compat                                       CXX14Compat
+#   -Wc++98-c++11-c++14-compat                       CXXPre1zCompat
+-Wc++14-compat-pedantic                              CXX14CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+-Wc++1y-extensions                                   CXX1y
+-Wc++1z-extensions                                   CXX1z
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre1yCompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre1yCompat
+#     -Wc++98-compat-bind-to-temporary-copy          CXX98CompatBindToTemporaryCopy
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+-Wc11-extensions                                     C11
+-Wc99-compat                                         C99Compat
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                           <<<NONE>>>
+-Wchar-align                                          <<<NONE>>>
+-Wclass-varargs                                      ClassVarargs
+#   -Wnon-pod-varargs                                NonPODVarargs
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconfig-macros                                      ConfigMacros
+-Wconsumed                                           Consumed
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wcuda-compat                                        CudaCompat
+-Wdangling-field                                     DanglingField
+-Wdealloc-in-category                                DeallocInCategory
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+#   -Wdeprecated-increment-bool                      DeprecatedIncrementBool
+#   -Wdeprecated-register                            DeprecatedRegister
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdeprecated-objc-isa-usage                          DeprecatedObjCIsaUsage
+-Wdeprecated-objc-pointer-introspection              ObjCPointerIntrospect
+#   -Wdeprecated-objc-pointer-introspection-performSelector ObjCPointerIntrospectPerformSelector
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdistributed-object-modifiers                       DistributedObjectModifiers
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+#   -Wdocumentation-unknown-command                  DocumentationUnknownCommand
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wenum-too-large                                     EnumTooLarge
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wfallback                                           Fallback
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wframe-larger-than=                                 BackendFrameLargerThanEQ
+-Wfunction-def-in-objc-container                     FunctionDefInObjCContainer
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-alignof-expression                         GNUAlignofExpression
+#   -Wgnu-anonymous-struct                           GNUAnonymousStruct
+#   -Wgnu-binary-literal                             GNUBinaryLiteral
+#   -Wgnu-case-range                                 GNUCaseRange
+#   -Wgnu-complex-integer                            GNUComplexInteger
+#   -Wgnu-compound-literal-initializer               GNUCompoundLiteralInitializer
+#   -Wgnu-conditional-omitted-operand                GNUConditionalOmittedOperand
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wgnu-empty-initializer                          GNUEmptyInitializer
+#   -Wgnu-empty-struct                               GNUEmptyStruct
+#   -Wgnu-flexible-array-initializer                 GNUFlexibleArrayInitializer
+#   -Wgnu-flexible-array-union-member                GNUFlexibleArrayUnionMember
+#   -Wgnu-folding-constant                           GNUFoldingConstant
+#   -Wgnu-imaginary-constant                         GNUImaginaryConstant
+#   -Wgnu-label-as-value                             GNULabelsAsValue
+#   -Wgnu-redeclared-enum                            GNURedeclaredEnum
+#   -Wgnu-statement-expression                       GNUStatementExpression
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+#   -Wgnu-string-literal-operator-template           GNUStringLiteralOperatorTemplate
+#   -Wgnu-union-cast                                 GNUUnionCast
+#   -Wgnu-variable-sized-type-not-at-end             GNUVariableSizedTypeNotAtEnd
+#   -Wgnu-zero-line-directive                        GNUZeroLineDirective
+#   -Wgnu-zero-variadic-macro-arguments              GNUZeroVariadicMacroArguments
+#   -Wredeclared-class-member                        RedeclaredClassMember
+#   -Wvla-extension                                  VLAExtension
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimport                                              <<<NONE>>>
+-Wincompatible-ms-struct                             IncompatibleMSStruct
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+#   -Wincompatible-pointer-types-discards-qualifiers IncompatiblePointerTypesDiscardsQualifiers
+-Wincomplete-module                                  IncompleteModule
+#   -Wincomplete-umbrella                            IncompleteUmbrella
+-Winfinite-recursion                                 InfiniteRecursion
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Winline-asm                                         BackendInlineAsm
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Wint-to-pointer-cast                                IntToPointerCast
+#   -Wint-to-void-pointer-cast                       IntToVoidPointerCast
+-Winvalid-command-line-argument                      InvalidCommandLineArgument
+-Winvalid-iboutlet                                   ObjCInvalidIBOutletProperty
+-Winvalid-noreturn                                   InvalidNoreturn
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Winvalid-source-encoding                            InvalidSourceEncoding
+-Wkeyword-compat                                     KeywordCompat
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wloop-analysis                                      LoopAnalysis
+-Wmacro-redefined                                    MacroRedefined
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmethod-signatures                                  MethodSignatures
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmissing-noreturn                                   MissingNoreturn
+-Wmodule-conflict                                    ModuleConflict
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnew-returns-null                                   OperatorNewReturnsNull
+-Wnewline-eof                                        NewlineEOF
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#       -Wpointer-bool-conversion                    PointerBoolConversion
+#       -Wundefined-bool-conversion                  UndefinedBoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#       -Wbitfield-constant-conversion               BitFieldConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wfloat-conversion                             FloatConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wobjc-literal-conversion                      ObjCLiteralConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-modular-include-in-module                      NonModularIncludeInModule
+#   -Wnon-modular-include-in-framework-module        NonModularIncludeInFrameworkModule
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-arithmetic                                    NullArithmetic
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-property-synthesis                            ObjCNoPropertyAutoSynthesis
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wobjc-string-concatenation                          ObjCStringConcatenation
+-Wold-style-cast                                     OldStyleCast
+-Wold-style-definition                                <<<NONE>>>
+-Wopenmp-clauses                                     OpenMPClauses
+-Wopenmp-loop-form                                   OpenMPLoopForm
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpass                                               BackendOptimizationRemark
+-Wpass-analysis                                      BackendOptimizationRemarkAnalysis
+-Wpass-failed                                        BackendOptimizationFailure
+-Wpass-missed                                        BackendOptimizationRemarkMissed
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wpragmas                                            Pragmas
+#   -Wignored-pragmas                                IgnoredPragmas
+#   -Wunknown-pragmas                                UnknownPragmas
+-Wprofile-instr-out-of-date                          ProfileInstrOutOfDate
+-Wprofile-instr-unprofiled                           ProfileInstrUnprofiled
+-Wprotocol                                           Protocol
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wredundant-decls                                     <<<NONE>>>
+-Wreinterpret-base-class                             ReinterpretBaseClass
+-Wremark-backend-plugin                              RemarkBackendPlugin
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wreturn-stack-address                               ReturnStackAddress
+-Wsection                                            Section
+-Wselector                                           Selector
+#   -Wselector-type-mismatch                         SelectorTypeMismatch
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+#   -Wunsequenced                                    Unsequenced
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wsizeof-pointer-memaccess                           SizeofPointerMemaccess
+-Wsource-uses-openmp                                 SourceUsesOpenMP
+-Wstack-protector                                     <<<NONE>>>
+-Wstatic-float-init                                  StaticFloatInit
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+-Wstatic-in-inline                                   StaticInInline
+-Wstatic-local-in-inline                             StaticLocalInInline
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstring-plus-char                                   StringPlusChar
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+#   -Wtautological-overlap-compare                   TautologicalOverlapCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+#   -Wtautological-undefined-compare                 TautologicalUndefinedCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+-Wthread-safety-beta                                 ThreadSafetyBeta
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wunavailable-declarations                           UnavailableDeclarations
+-Wundeclared-selector                                UndeclaredSelector
+-Wundefined-reinterpret-cast                         UndefinedReinterpretCast
+-Wunicode                                            Unicode
+-Wunknown-warning-option                             UnknownWarningOption
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunreachable-code-aggressive                        UnreachableCodeAggressive
+#   -Wunreachable-code                               UnreachableCode
+#     -Wunreachable-code-loop-increment              UnreachableCodeLoopIncrement
+#   -Wunreachable-code-break                         UnreachableCodeBreak
+#   -Wunreachable-code-return                        UnreachableCodeReturn
+-Wunsupported-friend                                 UnsupportedFriend
+-Wunused-command-line-argument                       UnusedCommandLineArgument
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvarargs                                            Varargs
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wvla                                                VLA
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wwritable-strings                               WritableStrings
+#     -Wdeprecated-writable-strings                  DeprecatedWritableStr
+#       -Wc++11-compat-deprecated-writable-strings   CXX11CompatDeprecatedWritableStr

--- a/warnings-toplevelonly-clang-3.6.txt
+++ b/warnings-toplevelonly-clang-3.6.txt
@@ -1,0 +1,468 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabsolute-value                                     AbsoluteValue
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+#   -Wpointer-bool-conversion                        PointerBoolConversion
+#   -Wstring-compare                                 StringCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wextern-c-compat                              ExternCCompat
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-designated-initializers                 ObjCDesignatedInit
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wself-move                                    SelfMove
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wsizeof-array-decay                           SizeofArrayDecay
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#       -Wstatic-self-init                           UninitializedStaticSelfInit
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-local-typedef                       UnusedLocalTypedef
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-property-ivar                       UnusedPropertyIvar
+#       -Wunused-value                               UnusedValue
+#         -Wunevaluated-expression                   UnevaluatedExpression
+#           -Wpotentially-evaluated-expression       PotentiallyEvaluatedExpression
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#         -Wunused-const-variable                    UnusedConstVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-not-parentheses                      LogicalNotParentheses
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Woverloaded-shift-op-parentheses              OverloadedShiftOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+#   -Wswitch-bool                                    SwitchBool
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Warray-bounds                                       ArrayBounds
+-Warray-bounds-pointer-arithmetic                    ArrayBoundsPointerArithmetic
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Wat-protocol                                        AtProtocol
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         Attributes
+#   -Wignored-attributes                             IgnoredAttributes
+#   -Wunknown-attributes                             UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbackend-plugin                                     BackendPlugin
+-Wbad-array-new-length                               BadArrayNewLength
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+#     -Wpointer-bool-conversion                      PointerBoolConversion
+#     -Wundefined-bool-conversion                    UndefinedBoolConversion
+-Wbridge-cast                                        ObjCBridge
+-Wbuiltin-macro-redefined                            BuiltinMacroRedefined
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++11-compat-pedantic                              CXX11CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre14CompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+-Wc++14-compat                                       CXX14Compat
+#   -Wc++98-c++11-c++14-compat                       CXXPre1zCompat
+-Wc++14-compat-pedantic                              CXX14CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+-Wc++1y-extensions                                    <<<NONE>>>
+#   -Wc++14-extensions                               CXX14
+-Wc++1z-extensions                                   CXX1z
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre14CompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wc11-extensions                                     C11
+-Wc99-compat                                         C99Compat
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                          CastQual
+-Wchar-align                                          <<<NONE>>>
+-Wclass-varargs                                      ClassVarargs
+#   -Wnon-pod-varargs                                NonPODVarargs
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconfig-macros                                      ConfigMacros
+-Wconsumed                                           Consumed
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wcstring-format-directive                           ObjCCStringFormat
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wcuda-compat                                        CudaCompat
+-Wdangling-field                                     DanglingField
+-Wdealloc-in-category                                DeallocInCategory
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdelete-incomplete                                  DeleteIncomplete
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+#   -Wdeprecated-increment-bool                      DeprecatedIncrementBool
+#   -Wdeprecated-register                            DeprecatedRegister
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdeprecated-objc-isa-usage                          DeprecatedObjCIsaUsage
+-Wdeprecated-objc-pointer-introspection              ObjCPointerIntrospect
+#   -Wdeprecated-objc-pointer-introspection-performSelector ObjCPointerIntrospectPerformSelector
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdistributed-object-modifiers                       DistributedObjectModifiers
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+#   -Wdocumentation-unknown-command                  DocumentationUnknownCommand
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wenum-too-large                                     EnumTooLarge
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wexplicit-initialize-call                           ExplicitInitializeCall
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wfallback                                           Fallback
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wframe-larger-than=                                 BackendFrameLargerThanEQ
+-Wfunction-def-in-objc-container                     FunctionDefInObjCContainer
+-Wfuture-compat                                      FutureCompat
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-alignof-expression                         GNUAlignofExpression
+#   -Wgnu-anonymous-struct                           GNUAnonymousStruct
+#   -Wgnu-binary-literal                             GNUBinaryLiteral
+#   -Wgnu-case-range                                 GNUCaseRange
+#   -Wgnu-complex-integer                            GNUComplexInteger
+#   -Wgnu-compound-literal-initializer               GNUCompoundLiteralInitializer
+#   -Wgnu-conditional-omitted-operand                GNUConditionalOmittedOperand
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wgnu-empty-initializer                          GNUEmptyInitializer
+#   -Wgnu-empty-struct                               GNUEmptyStruct
+#   -Wgnu-flexible-array-initializer                 GNUFlexibleArrayInitializer
+#   -Wgnu-flexible-array-union-member                GNUFlexibleArrayUnionMember
+#   -Wgnu-folding-constant                           GNUFoldingConstant
+#   -Wgnu-imaginary-constant                         GNUImaginaryConstant
+#   -Wgnu-label-as-value                             GNULabelsAsValue
+#   -Wgnu-redeclared-enum                            GNURedeclaredEnum
+#   -Wgnu-statement-expression                       GNUStatementExpression
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+#   -Wgnu-string-literal-operator-template           GNUStringLiteralOperatorTemplate
+#   -Wgnu-union-cast                                 GNUUnionCast
+#   -Wgnu-variable-sized-type-not-at-end             GNUVariableSizedTypeNotAtEnd
+#   -Wgnu-zero-line-directive                        GNUZeroLineDirective
+#   -Wgnu-zero-variadic-macro-arguments              GNUZeroVariadicMacroArguments
+#   -Wredeclared-class-member                        RedeclaredClassMember
+#   -Wvla-extension                                  VLAExtension
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimport                                              <<<NONE>>>
+-Wincompatible-ms-struct                             IncompatibleMSStruct
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+#   -Wincompatible-pointer-types-discards-qualifiers IncompatiblePointerTypesDiscardsQualifiers
+-Wincomplete-module                                  IncompleteModule
+#   -Wincomplete-umbrella                            IncompleteUmbrella
+#   -Wnon-modular-include-in-module                  NonModularIncludeInModule
+#     -Wnon-modular-include-in-framework-module      NonModularIncludeInFrameworkModule
+-Winconsistent-missing-override                      CXX11WarnOverrideMethod
+-Winfinite-recursion                                 InfiniteRecursion
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Winline-asm                                         BackendInlineAsm
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Wint-to-pointer-cast                                IntToPointerCast
+#   -Wint-to-void-pointer-cast                       IntToVoidPointerCast
+-Winvalid-command-line-argument                      InvalidCommandLineArgument
+#   -Wignored-optimization-argument                  IgnoredOptimizationArgument
+-Winvalid-iboutlet                                   ObjCInvalidIBOutletProperty
+-Winvalid-noreturn                                   InvalidNoreturn
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Winvalid-source-encoding                            InvalidSourceEncoding
+-Wkeyword-compat                                     KeywordCompat
+-Wkeyword-macro                                      KeywordAsMacro
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wloop-analysis                                      LoopAnalysis
+-Wmacro-redefined                                    MacroRedefined
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmethod-signatures                                  MethodSignatures
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmissing-noreturn                                   MissingNoreturn
+-Wmodule-build                                       ModuleBuild
+-Wmodule-conflict                                    ModuleConflict
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnew-returns-null                                   OperatorNewReturnsNull
+-Wnewline-eof                                        NewlineEOF
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#       -Wpointer-bool-conversion                    PointerBoolConversion
+#       -Wundefined-bool-conversion                  UndefinedBoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#       -Wbitfield-constant-conversion               BitFieldConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wfloat-conversion                             FloatConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wobjc-literal-conversion                      ObjCLiteralConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-arithmetic                                    NullArithmetic
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-multiple-method-names                         ObjCMultipleMethodNames
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-property-synthesis                            ObjCNoPropertyAutoSynthesis
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wobjc-string-concatenation                          ObjCStringConcatenation
+-Wold-style-cast                                     OldStyleCast
+-Wold-style-definition                                <<<NONE>>>
+-Wopenmp-clauses                                     OpenMPClauses
+-Wopenmp-loop-form                                   OpenMPLoopForm
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpass                                               BackendOptimizationRemark
+-Wpass-analysis                                      BackendOptimizationRemarkAnalysis
+-Wpass-failed                                        BackendOptimizationFailure
+-Wpass-missed                                        BackendOptimizationRemarkMissed
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wpragmas                                            Pragmas
+#   -Wignored-pragmas                                IgnoredPragmas
+#   -Wunknown-pragmas                                UnknownPragmas
+-Wprofile-instr-out-of-date                          ProfileInstrOutOfDate
+-Wprofile-instr-unprofiled                           ProfileInstrUnprofiled
+-Wproperty-access-dot-syntax                         PropertyAccessDotSyntax
+-Wproperty-attribute-mismatch                        PropertyAttr
+-Wprotocol                                           Protocol
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wredundant-decls                                     <<<NONE>>>
+-Wreinterpret-base-class                             ReinterpretBaseClass
+-Wremark-backend-plugin                              RemarkBackendPlugin
+-Wreserved-id-macro                                  ReservedIdAsMacro
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wreturn-stack-address                               ReturnStackAddress
+-Wsanitize-address                                   SanitizeAddressRemarks
+-Wsection                                            Section
+-Wselector                                           Selector
+#   -Wselector-type-mismatch                         SelectorTypeMismatch
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+#   -Wunsequenced                                    Unsequenced
+-Wserialized-diagnostics                             SerializedDiagnostics
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wsizeof-pointer-memaccess                           SizeofPointerMemaccess
+-Wsource-uses-openmp                                 SourceUsesOpenMP
+-Wstack-protector                                     <<<NONE>>>
+-Wstatic-float-init                                  StaticFloatInit
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+-Wstatic-in-inline                                   StaticInInline
+-Wstatic-local-in-inline                             StaticLocalInInline
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstring-plus-char                                   StringPlusChar
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+#   -Wtautological-overlap-compare                   TautologicalOverlapCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+#   -Wtautological-undefined-compare                 TautologicalUndefinedCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+#   -Wthread-safety-reference                        ThreadSafetyReference
+-Wthread-safety-beta                                 ThreadSafetyBeta
+-Wthread-safety-negative                             ThreadSafetyNegative
+-Wthread-safety-verbose                              ThreadSafetyVerbose
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wunavailable-declarations                           UnavailableDeclarations
+-Wundeclared-selector                                UndeclaredSelector
+-Wundefined-reinterpret-cast                         UndefinedReinterpretCast
+-Wunicode                                            Unicode
+-Wunknown-warning-option                             UnknownWarningOption
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunreachable-code-aggressive                        UnreachableCodeAggressive
+#   -Wunreachable-code                               UnreachableCode
+#     -Wunreachable-code-loop-increment              UnreachableCodeLoopIncrement
+#   -Wunreachable-code-break                         UnreachableCodeBreak
+#   -Wunreachable-code-return                        UnreachableCodeReturn
+-Wunsupported-friend                                 UnsupportedFriend
+-Wunused-command-line-argument                       UnusedCommandLineArgument
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-getter-return-value                         UnusedGetterReturnValue
+-Wunused-local-typedefs                               <<<NONE>>>
+#   -Wunused-local-typedef                           UnusedLocalTypedef
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvarargs                                            Varargs
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wvla                                                VLA
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wwritable-strings                               WritableStrings
+#     -Wdeprecated-writable-strings                  DeprecatedWritableStr
+#       -Wc++11-compat-deprecated-writable-strings   CXX11CompatDeprecatedWritableStr

--- a/warnings-toplevelonly-clang-3.7.txt
+++ b/warnings-toplevelonly-clang-3.7.txt
@@ -1,0 +1,488 @@
+-W                                                    <<<NONE>>>
+#   -Wextra                                          Extra
+#     -Wignored-qualifiers                           IgnoredQualifiers
+#     -Winitializer-overrides                        InitializerOverrides
+#     -Wmissing-field-initializers                   MissingFieldInitializers
+#     -Wmissing-method-return-type                   MissingMethodReturnType
+#     -Wsemicolon-before-method-body                 SemiBeforeMethodBody
+#     -Wsign-compare                                 SignCompare
+#     -Wunused-parameter                             UnusedParameter
+-W#pragma-messages                                   PoundPragmaMessage
+-W#warnings                                          PoundWarning
+-WIndependentClass-attribute                         IndependentClassAttribute
+-WNSObject-attribute                                 NSobjectAttribute
+-Wabi                                                 <<<NONE>>>
+-Wabsolute-value                                     AbsoluteValue
+-Wabstract-final-class                               AbstractFinalClass
+-Waddress                                             <<<NONE>>>
+#   -Wpointer-bool-conversion                        PointerBoolConversion
+#   -Wstring-compare                                 StringCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+-Waddress-of-temporary                               AddressOfTemporary
+-Waggregate-return                                    <<<NONE>>>
+-Wall                                                 <<<NONE>>>
+#   -Wmost                                           Most
+#     -Wcast-of-sel-type                             SelTypeCast
+#     -Wchar-subscripts                              CharSubscript
+#     -Wcomment                                      Comment
+#     -Wdelete-non-virtual-dtor                      DeleteNonVirtualDtor
+#     -Wextern-c-compat                              ExternCCompat
+#     -Wformat                                       Format
+#       -Wformat-extra-args                          FormatExtraArgs
+#       -Wformat-invalid-specifier                   FormatInvalidSpecifier
+#       -Wformat-security                            FormatSecurity
+#       -Wformat-y2k                                 FormatY2K
+#       -Wformat-zero-length                         FormatZeroLength
+#       -Wnonnull                                    NonNull
+#     -Wimplicit                                     Implicit
+#       -Wimplicit-function-declaration              ImplicitFunctionDeclare
+#       -Wimplicit-int                               ImplicitInt
+#     -Winfinite-recursion                           InfiniteRecursion
+#     -Wmismatched-tags                              MismatchedTags
+#     -Wmissing-braces                               MissingBraces
+#     -Wmove                                         Move
+#       -Wpessimizing-move                           PessimizingMove
+#       -Wredundant-move                             RedundantMove
+#       -Wself-move                                  SelfMove
+#     -Wmultichar                                    MultiChar
+#     -Wobjc-designated-initializers                 ObjCDesignatedInit
+#     -Wobjc-missing-super-calls                     ObjCMissingSuperCalls
+#     -Woverloaded-virtual                           OverloadedVirtual
+#     -Wprivate-extern                               PrivateExtern
+#     -Wreorder                                      Reorder
+#     -Wreturn-type                                  ReturnType
+#       -Wreturn-type-c-linkage                      ReturnTypeCLinkage
+#     -Wself-assign                                  SelfAssignment
+#       -Wself-assign-field                          SelfAssignmentField
+#     -Wself-move                                    SelfMove
+#     -Wsizeof-array-argument                        SizeofArrayArgument
+#     -Wsizeof-array-decay                           SizeofArrayDecay
+#     -Wstring-plus-int                              StringPlusInt
+#     -Wtrigraphs                                    Trigraphs
+#     -Wuninitialized                                Uninitialized
+#       -Wsometimes-uninitialized                    UninitializedSometimes
+#       -Wstatic-self-init                           UninitializedStaticSelfInit
+#     -Wunknown-pragmas                              UnknownPragmas
+#     -Wunused                                       Unused
+#       -Wunused-argument                            UnusedArgument
+#       -Wunused-function                            UnusedFunction
+#         -Wunneeded-internal-declaration            UnneededInternalDecl
+#       -Wunused-label                               UnusedLabel
+#       -Wunused-local-typedef                       UnusedLocalTypedef
+#       -Wunused-private-field                       UnusedPrivateField
+#       -Wunused-property-ivar                       UnusedPropertyIvar
+#       -Wunused-value                               UnusedValue
+#         -Wunevaluated-expression                   UnevaluatedExpression
+#           -Wpotentially-evaluated-expression       PotentiallyEvaluatedExpression
+#         -Wunused-comparison                        UnusedComparison
+#         -Wunused-result                            UnusedResult
+#       -Wunused-variable                            UnusedVariable
+#         -Wunused-const-variable                    UnusedConstVariable
+#     -Wvolatile-register-var                        VolatileRegisterVar
+#   -Wparentheses                                    Parentheses
+#     -Wbitwise-op-parentheses                       BitwiseOpParentheses
+#     -Wdangling-else                                DanglingElse
+#     -Wlogical-not-parentheses                      LogicalNotParentheses
+#     -Wlogical-op-parentheses                       LogicalOpParentheses
+#     -Woverloaded-shift-op-parentheses              OverloadedShiftOpParentheses
+#     -Wparentheses-equality                         ParenthesesOnEquality
+#     -Wshift-op-parentheses                         ShiftOpParentheses
+#   -Wswitch                                         Switch
+#   -Wswitch-bool                                    SwitchBool
+-Wambiguous-macro                                    AmbiguousMacro
+-Wambiguous-member-template                          AmbigMemberTemplate
+-Warc                                                AutomaticReferenceCounting
+#   -Warc-non-pod-memaccess                          ARCNonPodMemAccess
+#   -Warc-retain-cycles                              ARCRetainCycles
+#   -Warc-unsafe-retained-assign                     ARCUnsafeRetainedAssign
+-Warc-repeated-use-of-weak                           ARCRepeatedUseOfWeak
+#   -Warc-maybe-repeated-use-of-weak                 ARCRepeatedUseOfWeakMaybe
+-Warray-bounds                                       ArrayBounds
+-Warray-bounds-pointer-arithmetic                    ArrayBoundsPointerArithmetic
+-Wasm                                                ASM
+#   -Wasm-operand-widths                             ASMOperandWidths
+-Wat-protocol                                        AtProtocol
+-Watomic-properties                                  AtomicProperties
+#   -Wcustom-atomic-properties                       CustomAtomic
+#   -Wimplicit-atomic-properties                     ImplicitAtomic
+-Wattributes                                         Attributes
+#   -Wignored-attributes                             IgnoredAttributes
+#   -Wunknown-attributes                             UnknownAttributes
+-Wauto-import                                        AutoImport
+-Wavailability                                       Availability
+-Wbackend-plugin                                     BackendPlugin
+-Wbad-array-new-length                               BadArrayNewLength
+-Wbad-function-cast                                  BadFunctionCast
+-Wbind-to-temporary-copy                             BindToTemporaryCopy
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wbool-conversions                                    <<<NONE>>>
+#   -Wbool-conversion                                BoolConversion
+#     -Wpointer-bool-conversion                      PointerBoolConversion
+#     -Wundefined-bool-conversion                    UndefinedBoolConversion
+-Wbridge-cast                                        ObjCBridge
+-Wbuiltin-macro-redefined                            BuiltinMacroRedefined
+-Wbuiltin-requires-header                            BuiltinRequiresHeader
+-Wc++-compat                                         CXXCompat
+-Wc++0x-compat                                        <<<NONE>>>
+#   -Wc++11-compat                                   CXX11Compat
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+#     -Wc++11-compat-reserved-user-defined-literal   CXX11CompatReservedUserDefinedLiteral
+#     -Wc++11-narrowing                              CXX11Narrowing
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+-Wc++0x-extensions                                    <<<NONE>>>
+#   -Wc++11-extensions                               CXX11
+#     -Wc++11-extra-semi                             CXX11ExtraSemi
+#     -Wc++11-long-long                              CXX11LongLong
+-Wc++0x-narrowing                                     <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wc++11-compat-pedantic                              CXX11CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre14CompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+-Wc++14-compat                                       CXX14Compat
+#   -Wc++98-c++11-c++14-compat                       CXXPre1zCompat
+-Wc++14-compat-pedantic                              CXX14CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+-Wc++1y-extensions                                    <<<NONE>>>
+#   -Wc++14-extensions                               CXX14
+-Wc++1z-extensions                                   CXX1z
+-Wc++98-compat-pedantic                              CXX98CompatPedantic
+#   -Wc++98-c++11-c++14-compat-pedantic              CXXPre1zCompatPedantic
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#   -Wc++98-c++11-compat-pedantic                    CXXPre14CompatPedantic
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+#   -Wc++98-compat                                   CXX98Compat
+#     -Wc++98-c++11-c++14-compat                     CXXPre1zCompat
+#     -Wc++98-c++11-compat                           CXXPre14Compat
+#     -Wc++98-compat-local-type-template-args        CXX98CompatLocalTypeTemplateArgs
+#     -Wc++98-compat-unnamed-type-template-args      CXX98CompatUnnamedTypeTemplateArgs
+#   -Wc++98-compat-bind-to-temporary-copy            CXX98CompatBindToTemporaryCopy
+-Wc11-extensions                                     C11
+-Wc99-compat                                         C99Compat
+-Wc99-extensions                                     C99
+-Wcast-align                                         CastAlign
+-Wcast-qual                                          CastQual
+-Wchar-align                                          <<<NONE>>>
+-Wclass-varargs                                      ClassVarargs
+#   -Wnon-pod-varargs                                NonPODVarargs
+-Wcomments                                            <<<NONE>>>
+#   -Wcomment                                        Comment
+-Wcompare-distinct-pointer-types                     CompareDistinctPointerType
+-Wconditional-uninitialized                          UninitializedMaybe
+-Wconfig-macros                                      ConfigMacros
+-Wconsumed                                           Consumed
+-Wconversion-null                                     <<<NONE>>>
+#   -Wnull-conversion                                NullConversion
+-Wcovered-switch-default                             CoveredSwitchDefault
+-Wcstring-format-directive                           ObjCCStringFormat
+-Wctor-dtor-privacy                                   <<<NONE>>>
+-Wcuda-compat                                        CudaCompat
+-Wdangling-field                                     DanglingField
+-Wdealloc-in-category                                DeallocInCategory
+-Wdelegating-ctor-cycles                             DelegatingCtorCycles
+-Wdelete-incomplete                                  DeleteIncomplete
+-Wdeprecated                                         Deprecated
+#   -Wdeprecated-declarations                        DeprecatedDeclarations
+#   -Wdeprecated-increment-bool                      DeprecatedIncrementBool
+#   -Wdeprecated-register                            DeprecatedRegister
+#   -Wdeprecated-writable-strings                    DeprecatedWritableStr
+#     -Wc++11-compat-deprecated-writable-strings     CXX11CompatDeprecatedWritableStr
+-Wdeprecated-implementations                         DeprecatedImplementations
+-Wdeprecated-objc-isa-usage                          DeprecatedObjCIsaUsage
+-Wdeprecated-objc-pointer-introspection              ObjCPointerIntrospect
+#   -Wdeprecated-objc-pointer-introspection-performSelector ObjCPointerIntrospectPerformSelector
+-Wdisabled-optimization                               <<<NONE>>>
+-Wdiscard-qual                                        <<<NONE>>>
+-Wdistributed-object-modifiers                       DistributedObjectModifiers
+-Wdiv-by-zero                                         <<<NONE>>>
+-Wdivision-by-zero                                   DivZero
+-Wdocumentation                                      Documentation
+#   -Wdocumentation-deprecated-sync                  DocumentationDeprecatedSync
+#   -Wdocumentation-html                             DocumentationHTML
+-Wdocumentation-pedantic                             DocumentationPedantic
+#   -Wdocumentation-unknown-command                  DocumentationUnknownCommand
+-Wduplicate-decl-specifier                           DuplicateDeclSpecifier
+-Wduplicate-method-arg                               DuplicateArgDecl
+-Wduplicate-method-match                             MethodDuplicate
+-Weffc++                                              <<<NONE>>>
+-Wempty-body                                         EmptyBody
+-Wendif-labels                                        <<<NONE>>>
+#   -Wextra-tokens                                   ExtraTokens
+-Wenum-too-large                                     EnumTooLarge
+-Wexceptions                                         Exceptions
+-Wexit-time-destructors                              ExitTimeDestructors
+-Wexplicit-initialize-call                           ExplicitInitializeCall
+-Wextra-semi                                         ExtraSemi
+#   -Wc++11-extra-semi                               CXX11ExtraSemi
+-Wfallback                                           Fallback
+-Wflag-enum                                          FlagEnum
+-Wflexible-array-extensions                          FlexibleArrayExtensions
+-Wformat-non-iso                                     FormatNonStandard
+-Wformat-pedantic                                    FormatPedantic
+-Wformat=2                                           Format2
+#   -Wformat-nonliteral                              FormatNonLiteral
+#   -Wformat-security                                FormatSecurity
+#   -Wformat-y2k                                     FormatY2K
+-Wfour-char-constants                                FourByteMultiChar
+-Wframe-larger-than=                                 BackendFrameLargerThanEQ
+-Wfunction-def-in-objc-container                     FunctionDefInObjCContainer
+-Wfuture-compat                                      FutureCompat
+-Wgcc-compat                                         GccCompat
+-Wglobal-constructors                                GlobalConstructors
+-Wgnu                                                GNU
+#   -Wgnu-alignof-expression                         GNUAlignofExpression
+#   -Wgnu-anonymous-struct                           GNUAnonymousStruct
+#   -Wgnu-binary-literal                             GNUBinaryLiteral
+#   -Wgnu-case-range                                 GNUCaseRange
+#   -Wgnu-complex-integer                            GNUComplexInteger
+#   -Wgnu-compound-literal-initializer               GNUCompoundLiteralInitializer
+#   -Wgnu-conditional-omitted-operand                GNUConditionalOmittedOperand
+#   -Wgnu-designator                                 GNUDesignator
+#   -Wgnu-empty-initializer                          GNUEmptyInitializer
+#   -Wgnu-empty-struct                               GNUEmptyStruct
+#   -Wgnu-flexible-array-initializer                 GNUFlexibleArrayInitializer
+#   -Wgnu-flexible-array-union-member                GNUFlexibleArrayUnionMember
+#   -Wgnu-folding-constant                           GNUFoldingConstant
+#   -Wgnu-imaginary-constant                         GNUImaginaryConstant
+#   -Wgnu-label-as-value                             GNULabelsAsValue
+#   -Wgnu-redeclared-enum                            GNURedeclaredEnum
+#   -Wgnu-statement-expression                       GNUStatementExpression
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+#   -Wgnu-string-literal-operator-template           GNUStringLiteralOperatorTemplate
+#   -Wgnu-union-cast                                 GNUUnionCast
+#   -Wgnu-variable-sized-type-not-at-end             GNUVariableSizedTypeNotAtEnd
+#   -Wgnu-zero-line-directive                        GNUZeroLineDirective
+#   -Wgnu-zero-variadic-macro-arguments              GNUZeroVariadicMacroArguments
+#   -Wredeclared-class-member                        RedeclaredClassMember
+#   -Wvla-extension                                  VLAExtension
+#   -Wzero-length-array                              ZeroLengthArray
+-Wheader-hygiene                                     HeaderHygiene
+-Wimplicit-conversion-floating-point-to-bool         ImplicitConversionFloatingPointToBool
+-Wimplicit-fallthrough                               ImplicitFallthrough
+#   -Wimplicit-fallthrough-per-function              ImplicitFallthroughPerFunction
+-Wimplicitly-unsigned-literal                        ImplicitlyUnsignedLiteral
+-Wimport                                              <<<NONE>>>
+-Wincompatible-ms-struct                             IncompatibleMSStruct
+-Wincompatible-pointer-types                         IncompatiblePointerTypes
+#   -Wincompatible-pointer-types-discards-qualifiers IncompatiblePointerTypesDiscardsQualifiers
+-Wincomplete-module                                  IncompleteModule
+#   -Wincomplete-umbrella                            IncompleteUmbrella
+#   -Wnon-modular-include-in-module                  NonModularIncludeInModule
+#     -Wnon-modular-include-in-framework-module      NonModularIncludeInFrameworkModule
+-Winconsistent-missing-override                      CXX11WarnOverrideMethod
+-Winit-self                                           <<<NONE>>>
+-Winline                                              <<<NONE>>>
+-Winline-asm                                         BackendInlineAsm
+-Wint-conversions                                     <<<NONE>>>
+#   -Wint-conversion                                 IntConversion
+-Wint-to-pointer-cast                                IntToPointerCast
+#   -Wint-to-void-pointer-cast                       IntToVoidPointerCast
+-Winvalid-command-line-argument                      InvalidCommandLineArgument
+#   -Wignored-optimization-argument                  IgnoredOptimizationArgument
+-Winvalid-iboutlet                                   ObjCInvalidIBOutletProperty
+-Winvalid-noreturn                                   InvalidNoreturn
+-Winvalid-offsetof                                   InvalidOffsetof
+-Winvalid-pch                                         <<<NONE>>>
+-Winvalid-pp-token                                   InvalidPPToken
+-Winvalid-source-encoding                            InvalidSourceEncoding
+-Wkeyword-compat                                     KeywordCompat
+-Wkeyword-macro                                      KeywordAsMacro
+-Wknr-promoted-parameter                             KNRPromotedParameter
+-Wlarge-by-value-copy                                LargeByValueCopy
+-Wlocal-type-template-args                           LocalTypeTemplateArgs
+#   -Wc++98-compat-local-type-template-args          CXX98CompatLocalTypeTemplateArgs
+-Wlong-long                                          LongLong
+#   -Wc++11-long-long                                CXX11LongLong
+-Wloop-analysis                                      LoopAnalysis
+#   -Wfor-loop-analysis                              ForLoopAnalysis
+#   -Wrange-loop-analysis                            RangeLoopAnalysis
+-Wmacro-redefined                                    MacroRedefined
+-Wmain                                               Main
+-Wmain-return-type                                   MainReturnType
+-Wmalformed-warning-check                            MalformedWarningCheck
+-Wmethod-signatures                                  MethodSignatures
+-Wmicrosoft                                          Microsoft
+-Wmismatched-parameter-types                         MismatchedParameterTypes
+-Wmismatched-return-types                            MismatchedReturnTypes
+-Wmissing-declarations                               MissingDeclarations
+-Wmissing-format-attribute                            <<<NONE>>>
+-Wmissing-include-dirs                                <<<NONE>>>
+-Wmissing-noreturn                                   MissingNoreturn
+-Wmodule-build                                       ModuleBuild
+-Wmodule-conflict                                    ModuleConflict
+-Wnarrowing                                           <<<NONE>>>
+#   -Wc++11-narrowing                                CXX11Narrowing
+-Wnested-externs                                      <<<NONE>>>
+-Wnew-returns-null                                   OperatorNewReturnsNull
+-Wnewline-eof                                        NewlineEOF
+-Wnon-gcc                                            NonGCC
+#   -Wconversion                                     Conversion
+#     -Wbool-conversion                              BoolConversion
+#       -Wpointer-bool-conversion                    PointerBoolConversion
+#       -Wundefined-bool-conversion                  UndefinedBoolConversion
+#     -Wconstant-conversion                          ConstantConversion
+#       -Wbitfield-constant-conversion               BitFieldConstantConversion
+#     -Wenum-conversion                              EnumConversion
+#     -Wfloat-conversion                             FloatConversion
+#     -Wint-conversion                               IntConversion
+#     -Wliteral-conversion                           LiteralConversion
+#     -Wnon-literal-null-conversion                  NonLiteralNullConversion
+#     -Wnull-conversion                              NullConversion
+#     -Wobjc-literal-conversion                      ObjCLiteralConversion
+#     -Wshorten-64-to-32                             Shorten64To32
+#     -Wsign-conversion                              SignConversion
+#     -Wstring-conversion                            StringConversion
+#   -Wliteral-range                                  LiteralRange
+#   -Wsign-compare                                   SignCompare
+-Wnon-virtual-dtor                                   NonVirtualDtor
+-Wnonportable-cfstrings                               <<<NONE>>>
+-Wnull-arithmetic                                    NullArithmetic
+-Wnull-character                                     NullCharacter
+-Wnull-dereference                                   NullDereference
+-Wnullability                                        Nullability
+-Wnullability-completeness                           NullabilityCompleteness
+-Wnullability-declspec                               NullabilityDeclSpec
+-Wnullable-to-nonnull-conversion                     NullableToNonNullConversion
+-Wobjc-cocoa-api                                     ObjCCocoaAPI
+#   -Wobjc-redundant-api-use                         ObjCRedundantAPIUse
+#     -Wobjc-redundant-literal-use                   ObjCRedundantLiteralUse
+-Wobjc-literal-compare                               ObjCLiteralComparison
+#   -Wobjc-string-compare                            ObjCStringComparison
+-Wobjc-method-access                                 MethodAccess
+-Wobjc-multiple-method-names                         ObjCMultipleMethodNames
+-Wobjc-noncopy-retain-block-property                 ObjCRetainBlockProperty
+-Wobjc-nonunified-exceptions                         ObjCNonUnifiedException
+-Wobjc-property-implementation                       ObjCPropertyImpl
+-Wobjc-property-no-attribute                         ObjCPropertyNoAttribute
+-Wobjc-property-synthesis                            ObjCNoPropertyAutoSynthesis
+-Wobjc-protocol-method-implementation                ObjCProtocolMethodImpl
+-Wobjc-protocol-qualifiers                           ObjCProtocolQualifiers
+-Wobjc-readonly-with-setter-property                 ObjCReadonlyPropertyHasSetter
+-Wobjc-root-class                                    ObjCRootClass
+-Wobjc-string-concatenation                          ObjCStringConcatenation
+-Wold-style-cast                                     OldStyleCast
+-Wold-style-definition                                <<<NONE>>>
+-Wopenmp-clauses                                     OpenMPClauses
+-Wopenmp-loop-form                                   OpenMPLoopForm
+-Wout-of-line-declaration                            OutOfLineDeclaration
+-Wover-aligned                                       OveralignedType
+-Woverflow                                            <<<NONE>>>
+-Woverlength-strings                                 OverlengthStrings
+-Woverriding-method-mismatch                         OverridingMethodMismatch
+-Wpacked                                             Packed
+-Wpadded                                             Padded
+-Wpartial-availability                               PartialAvailability
+-Wpass                                               BackendOptimizationRemark
+-Wpass-analysis                                      BackendOptimizationRemarkAnalysis
+-Wpass-failed                                        BackendOptimizationFailure
+-Wpass-missed                                        BackendOptimizationRemarkMissed
+-Wpedantic                                           Pedantic
+-Wpointer-arith                                      PointerArith
+-Wpointer-to-int-cast                                 <<<NONE>>>
+-Wpragmas                                            Pragmas
+#   -Wignored-pragmas                                IgnoredPragmas
+#   -Wunknown-pragmas                                UnknownPragmas
+-Wprofile-instr-out-of-date                          ProfileInstrOutOfDate
+-Wprofile-instr-unprofiled                           ProfileInstrUnprofiled
+-Wproperty-access-dot-syntax                         PropertyAccessDotSyntax
+-Wproperty-attribute-mismatch                        PropertyAttr
+-Wprotocol                                           Protocol
+-Wreceiver-expr                                      ObjCReceiver
+-Wreceiver-forward-class                             ForwardClassReceiver
+-Wreceiver-is-weak                                    <<<NONE>>>
+-Wredundant-decls                                     <<<NONE>>>
+-Wreinterpret-base-class                             ReinterpretBaseClass
+-Wremark-backend-plugin                              RemarkBackendPlugin
+-Wreserved-id-macro                                  ReservedIdAsMacro
+-Wreserved-user-defined-literal                      ReservedUserDefinedLiteral
+#   -Wc++11-compat-reserved-user-defined-literal     CXX11CompatReservedUserDefinedLiteral
+-Wreturn-stack-address                               ReturnStackAddress
+-Wsanitize-address                                   SanitizeAddressRemarks
+-Wsection                                            Section
+-Wselector                                           Selector
+#   -Wselector-type-mismatch                         SelectorTypeMismatch
+-Wsentinel                                           Sentinel
+-Wsequence-point                                      <<<NONE>>>
+#   -Wunsequenced                                    Unsequenced
+-Wserialized-diagnostics                             SerializedDiagnostics
+-Wshadow                                             Shadow
+-Wsign-promo                                          <<<NONE>>>
+-Wsizeof-pointer-memaccess                           SizeofPointerMemaccess
+-Wsource-uses-openmp                                 SourceUsesOpenMP
+-Wstack-protector                                     <<<NONE>>>
+-Wstatic-float-init                                  StaticFloatInit
+#   -Wgnu-static-float-init                          GNUStaticFloatInit
+-Wstatic-in-inline                                   StaticInInline
+-Wstatic-local-in-inline                             StaticLocalInInline
+-Wstrict-aliasing                                     <<<NONE>>>
+-Wstrict-aliasing=0                                   <<<NONE>>>
+-Wstrict-aliasing=1                                   <<<NONE>>>
+-Wstrict-aliasing=2                                   <<<NONE>>>
+-Wstrict-overflow                                     <<<NONE>>>
+-Wstrict-overflow=0                                   <<<NONE>>>
+-Wstrict-overflow=1                                   <<<NONE>>>
+-Wstrict-overflow=2                                   <<<NONE>>>
+-Wstrict-overflow=3                                   <<<NONE>>>
+-Wstrict-overflow=4                                   <<<NONE>>>
+-Wstrict-overflow=5                                   <<<NONE>>>
+-Wstrict-prototypes                                   <<<NONE>>>
+-Wstrict-selector-match                              StrictSelector
+-Wstring-plus-char                                   StringPlusChar
+-Wstrncat-size                                       StrncatSize
+-Wsuper-class-method-mismatch                        SuperSubClassMismatch
+-Wswitch-default                                      <<<NONE>>>
+-Wswitch-enum                                        SwitchEnum
+-Wsynth                                               <<<NONE>>>
+-Wtautological-compare                               TautologicalCompare
+#   -Wtautological-constant-out-of-range-compare     TautologicalOutOfRangeCompare
+#   -Wtautological-overlap-compare                   TautologicalOverlapCompare
+#   -Wtautological-pointer-compare                   TautologicalPointerCompare
+#   -Wtautological-undefined-compare                 TautologicalUndefinedCompare
+-Wthread-safety                                      ThreadSafety
+#   -Wthread-safety-analysis                         ThreadSafetyAnalysis
+#   -Wthread-safety-attributes                       ThreadSafetyAttributes
+#   -Wthread-safety-precise                          ThreadSafetyPrecise
+#   -Wthread-safety-reference                        ThreadSafetyReference
+-Wthread-safety-beta                                 ThreadSafetyBeta
+-Wthread-safety-negative                             ThreadSafetyNegative
+-Wthread-safety-verbose                              ThreadSafetyVerbose
+-Wtype-limits                                         <<<NONE>>>
+-Wtype-safety                                        TypeSafety
+-Wunavailable-declarations                           UnavailableDeclarations
+-Wundeclared-selector                                UndeclaredSelector
+-Wundefined-reinterpret-cast                         UndefinedReinterpretCast
+-Wunicode                                            Unicode
+-Wunknown-sanitizers                                 UnknownSanitizers
+-Wunknown-warning-option                             UnknownWarningOption
+-Wunnamed-type-template-args                         UnnamedTypeTemplateArgs
+#   -Wc++98-compat-unnamed-type-template-args        CXX98CompatUnnamedTypeTemplateArgs
+-Wunreachable-code-aggressive                        UnreachableCodeAggressive
+#   -Wunreachable-code                               UnreachableCode
+#     -Wunreachable-code-loop-increment              UnreachableCodeLoopIncrement
+#   -Wunreachable-code-break                         UnreachableCodeBreak
+#   -Wunreachable-code-return                        UnreachableCodeReturn
+-Wunsupported-friend                                 UnsupportedFriend
+-Wunsupported-nan                                    UnsupportedNan
+-Wunused-command-line-argument                       UnusedCommandLineArgument
+-Wunused-exception-parameter                         UnusedExceptionParameter
+-Wunused-getter-return-value                         UnusedGetterReturnValue
+-Wunused-local-typedefs                               <<<NONE>>>
+#   -Wunused-local-typedef                           UnusedLocalTypedef
+-Wunused-member-function                             UnusedMemberFunction
+#   -Wunneeded-member-function                       UnneededMemberFunction
+-Wused-but-marked-unused                             UsedButMarkedUnused
+-Wuser-defined-literals                              UserDefinedLiterals
+-Wvarargs                                            Varargs
+-Wvariadic-macros                                    VariadicMacros
+-Wvector-conversions                                  <<<NONE>>>
+#   -Wvector-conversion                              VectorConversion
+-Wvexing-parse                                       VexingParse
+-Wvisibility                                         Visibility
+-Wvla                                                VLA
+-Wwrite-strings                                      GCCWriteStrings
+#   -Wwritable-strings                               WritableStrings
+#     -Wdeprecated-writable-strings                  DeprecatedWritableStr
+#       -Wc++11-compat-deprecated-writable-strings   CXX11CompatDeprecatedWritableStr


### PR DESCRIPTION
- Added a --top-nodes-only flag, which cuts out duplication of nodes such that they only appear once. If a node has a parent, it is only displayed under that parent.
- Added a --show-class flag, which displays the class name in a second column, which is useful for seeing the diagnostics that have no associated class (and are thus dummy diagnostics which have no effect).
- Added warning output files alongside the existing ones.
- Added change details to the README. Added warning output for Clang 3.7 to the README.
