### PR TITLE
Clarify that antlr 4.5 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ compiler option data files. Other requirements are following (plus
 their dependencies):
 
 * [Ninja](https://ninja-build.org/)
-* [ANTLR4](http://www.antlr.org/)
+* [ANTLR 4.5](http://www.antlr.org/)
 * [Python 2.7](https://www.python.org/)
-* [antlr4-python2-runtime](https://pypi.python.org/pypi/antlr4-python2-runtime/)
+* [antlr4-python2-runtime 4.5.2.1](https://pypi.python.org/pypi/antlr4-python2-runtime/)
 
 ## Building
 


### PR DESCRIPTION
This PR makes a small update to the readme to clarify that ANTLR 4.5 (and corresponding version of the python runtime) is required. 4.6 is released now, but running the parse scripts with that newer version results in AttributeError deep within the antlr python runtime.