### PR TITLE
Enhance gcc output to show warnings enabled by default

### DIFF
--- a/gcc/warnings-gcc-diff-3.4-4.0.txt
+++ b/gcc/warnings-gcc-diff-3.4-4.0.txt
@@ -1,6 +1,26 @@
-+-Wmissing-field-initializers
+--Wdeprecated
+--Wdeprecated-declarations
++-Wdeprecated # (enabled by default)
++-Wdeprecated-declarations # (enabled by default)
+--Wdiv-by-zero
++-Wdiv-by-zero # (enabled by default)
+--Wimplicit-function-declaration
++-Wimplicit-function-declaration # (enabled by default)
+--Winvalid-offsetof
++-Winvalid-offsetof # (enabled by default)
+--Wlong-long
++-Wlong-long # (enabled by default)
++-Wmissing-field-initializers # (enabled by default)
 +-Wmissing-include-dirs
-+-Wpointer-sign
+--Wnon-template-friend
++-Wnon-template-friend # (enabled by default)
+--Wpmf-conversions
++-Wpmf-conversions # (enabled by default)
+--Wprotocol
++-Wpointer-sign # (enabled by default)
++-Wprotocol # (enabled by default)
+--Wsign-compare
++-Wsign-compare # (enabled by default)
 +-Wstrict-aliasing=
 +-Wstrict-null-sentinel
 +-Wvariadic-macros

--- a/gcc/warnings-gcc-diff-4.0-4.1.txt
+++ b/gcc/warnings-gcc-diff-4.0-4.1.txt
@@ -1,10 +1,10 @@
 +-Wassign-intercept
-+-Wattributes
++-Wattributes # (enabled by default)
 +-Wc++-compat
-+-Wint-to-pointer-cast
++-Wint-to-pointer-cast # (enabled by default)
 +-Wnormalized=
-+-Wpointer-to-int-cast
-+-Wpragmas
++-Wpointer-to-int-cast # (enabled by default)
++-Wpragmas # (enabled by default)
 +-Wstack-protector
 +-Wstrict-selector-match
 +-Wunsafe-loop-optimizations

--- a/gcc/warnings-gcc-diff-4.1-4.2.txt
+++ b/gcc/warnings-gcc-diff-4.1-4.2.txt
@@ -1,6 +1,6 @@
 +-Waddress
-+-Woverflow
-+-Woverlength-strings
-+-Woverride-init
++-Woverflow # (enabled by default)
++-Woverlength-strings # (enabled by default)
++-Woverride-init # (enabled by default)
 +-Wstrict-overflow
 +-Wstrict-overflow=

--- a/gcc/warnings-gcc-diff-4.2-4.3.txt
+++ b/gcc/warnings-gcc-diff-4.2-4.3.txt
@@ -1,14 +1,14 @@
 +-Warray-bounds
 +-Wc++0x-compat
-+-Wclobbered
++-Wclobbered # (enabled by default)
 +-Wcoverage-mismatch
-+-Wempty-body
++-Wempty-body # (enabled by default)
 +-Wformat-contains-nul
-+-Wignored-qualifiers
++-Wignored-qualifiers # (enabled by default)
 +-Wlogical-op
-+-Wmissing-parameter-type
-+-Wold-style-declaration
-+-Wsign-conversion
++-Wmissing-parameter-type # (enabled by default)
++-Wold-style-declaration # (enabled by default)
++-Wsign-conversion # (enabled by default)
 +-Wtraditional-conversion
-+-Wtype-limits
-+-Wvla
++-Wtype-limits # (enabled by default)
++-Wvla # (enabled by default)

--- a/gcc/warnings-gcc-diff-4.3-4.4.txt
+++ b/gcc/warnings-gcc-diff-4.3-4.4.txt
@@ -1,8 +1,20 @@
 +-Wbuiltin-macro-redefined
-+-Wenum-compare
++-Wenum-compare # (enabled by default)
 +-Wframe-larger-than=
 +-Wlarger-than=
-+-Wmudflap
-+-Wpacked-bitfield-compat
-+-Wpsabi
-+-Wsync-nand
+--Wmain
++-Wmain # (enabled by default)
++-Wmudflap # (enabled by default)
++-Wpacked-bitfield-compat # (enabled by default)
++-Wpsabi # (enabled by default)
++-Wsync-nand # (enabled by default)
+--Wunused-function
+--Wunused-label
++-Wunused-function # (enabled by default)
++-Wunused-label # (enabled by default)
+--Wunused-parameter
+--Wunused-value
+--Wunused-variable
++-Wunused-parameter # (enabled by default)
++-Wunused-value # (enabled by default)
++-Wunused-variable # (enabled by default)

--- a/gcc/warnings-gcc-diff-4.4-4.5.txt
+++ b/gcc/warnings-gcc-diff-4.4-4.5.txt
@@ -1,4 +1,6 @@
-+-Wconversion-null
-+-Wjump-misses-init
++-Wconversion-null # (enabled by default)
++-Wjump-misses-init # (enabled by default)
+--Wuninitialized
++-Wuninitialized # (enabled by default)
 +-Wunsuffixed-float-constants
-+-Wunused-result
++-Wunused-result # (enabled by default)

--- a/gcc/warnings-gcc-diff-4.5-4.6.txt
+++ b/gcc/warnings-gcc-diff-4.5-4.6.txt
@@ -1,14 +1,20 @@
-+-Wcpp
+--Wcoverage-mismatch
++-Wcoverage-mismatch # (enabled by default)
++-Wcpp # (enabled by default)
 +-Wdouble-promotion
+--Wimplicit
++-Wimplicit # (enabled by default)
+--Wimplicit-int
 --Wimport
++-Wimplicit-int # (enabled by default)
 +-Wimport # DUMMY switch
 +-Wnoexcept
-+-Wproperty-assign-default
++-Wproperty-assign-default # (enabled by default)
 +-Wsuggest-attribute=const
 +-Wsuggest-attribute=noreturn
 +-Wsuggest-attribute=pure
 +-Wtrampolines
 --Wunreachable-code
 +-Wunreachable-code # DUMMY switch
-+-Wunused-but-set-parameter
-+-Wunused-but-set-variable
++-Wunused-but-set-parameter # (enabled by default)
++-Wunused-but-set-variable # (enabled by default)

--- a/gcc/warnings-gcc-diff-4.6-4.7.txt
+++ b/gcc/warnings-gcc-diff-4.6-4.7.txt
@@ -1,9 +1,9 @@
 +-Wc++11-compat
 +-Wdelete-non-virtual-dtor
-+-Wfree-nonheap-object
-+-Winvalid-memory-model
++-Wfree-nonheap-object # (enabled by default)
++-Winvalid-memory-model # (enabled by default)
 +-Wmaybe-uninitialized
-+-Wnarrowing
++-Wnarrowing # (enabled by default)
 +-Wstack-usage=
 +-Wunused-local-typedefs
 +-Wvector-operation-performance

--- a/gcc/warnings-gcc-diff-4.7-4.8.txt
+++ b/gcc/warnings-gcc-diff-4.7-4.8.txt
@@ -1,11 +1,59 @@
 +-Wabi-tag
-+-Waggressive-loop-optimizations
-+-Winherited-variadic-ctor
++-Waggressive-loop-optimizations # (enabled by default)
+--Wclobbered # (enabled by default)
++-Wclobbered
+--Wempty-body # (enabled by default)
++-Wempty-body
+--Wignored-qualifiers # (enabled by default)
+--Wimplicit # (enabled by default)
++-Wignored-qualifiers
++-Wimplicit
+--Wimplicit-int # (enabled by default)
++-Wimplicit-int
++-Winherited-variadic-ctor # (enabled by default)
+--Wjump-misses-init # (enabled by default)
++-Wjump-misses-init
 +-Wliteral-suffix
+--Wmissing-field-initializers # (enabled by default)
++-Wmissing-field-initializers
+--Wmissing-parameter-type # (enabled by default)
++-Wmissing-parameter-type
+--Wold-style-declaration # (enabled by default)
++-Wold-style-declaration
+--Woverlength-strings # (enabled by default)
++-Woverlength-strings
+--Woverride-init # (enabled by default)
++-Woverride-init
 +-Wpedantic
-+-Wreturn-local-addr
+--Wpointer-sign # (enabled by default)
++-Wpointer-sign
++-Wreturn-local-addr # (enabled by default)
+--Wsign-compare # (enabled by default)
+--Wsign-conversion # (enabled by default)
++-Wsign-compare
++-Wsign-conversion
 +-Wsizeof-pointer-memaccess
 +-Wsuggest-attribute=format
+--Wtype-limits # (enabled by default)
++-Wtype-limits
+--Wuninitialized # (enabled by default)
++-Wuninitialized
+--Wunused-but-set-parameter # (enabled by default)
+--Wunused-but-set-variable # (enabled by default)
+--Wunused-function # (enabled by default)
+--Wunused-label # (enabled by default)
++-Wunused-but-set-parameter
++-Wunused-but-set-variable
++-Wunused-function
++-Wunused-label
+--Wunused-parameter # (enabled by default)
++-Wunused-parameter
+--Wunused-value # (enabled by default)
+--Wunused-variable # (enabled by default)
+--Wvariadic-macros
++-Wunused-value
++-Wunused-variable
 +-Wuseless-cast
-+-Wvarargs
-+-Wvirtual-move-assign
++-Wvarargs # (enabled by default)
++-Wvariadic-macros # (enabled by default)
++-Wvirtual-move-assign # (enabled by default)

--- a/gcc/warnings-gcc-diff-4.8-4.9.txt
+++ b/gcc/warnings-gcc-diff-4.8-4.9.txt
@@ -1,7 +1,7 @@
 +-Wconditionally-supported
 +-Wdate-time
-+-Wdelete-incomplete
++-Wdelete-incomplete # (enabled by default)
 +-Wfloat-conversion
---Wmudflap
+--Wmudflap # (enabled by default)
 +-Wmudflap # DUMMY switch
 +-Wopenmp-simd

--- a/gcc/warnings-gcc-diff-4.9-5.txt
+++ b/gcc/warnings-gcc-diff-4.9-5.txt
@@ -1,26 +1,38 @@
 +-Wabi=
 +-Warray-bounds=
+--Wbuiltin-macro-redefined
 +-Wbool-compare
++-Wbuiltin-macro-redefined # (enabled by default)
 +-Wc++14-compat
-+-Wc90-c99-compat
-+-Wc99-c11-compat
++-Wc90-c99-compat # (enabled by default)
++-Wc99-c11-compat # (enabled by default)
 +-Wchkp
-+-Wdesignated-init
-+-Wdiscarded-array-qualifiers
-+-Wdiscarded-qualifiers
+--Wdeclaration-after-statement
++-Wdeclaration-after-statement # (enabled by default)
++-Wdesignated-init # (enabled by default)
++-Wdiscarded-array-qualifiers # (enabled by default)
++-Wdiscarded-qualifiers # (enabled by default)
+--Wendif-labels
++-Wendif-labels # (enabled by default)
 +-Wformat-signedness
-+-Wincompatible-pointer-types
-+-Wint-conversion
+--Wimplicit-int
++-Wimplicit-int # (enabled by default)
++-Wincompatible-pointer-types # (enabled by default)
++-Wint-conversion # (enabled by default)
+--Wliteral-suffix
++-Wliteral-suffix # (enabled by default)
 +-Wlogical-not-parentheses
 +-Wmemset-transposed-args
 +-Wnormalized
-+-Wodr
-+-Wshadow-ivar
-+-Wshift-count-negative
-+-Wshift-count-overflow
++-Wodr # (enabled by default)
++-Wshadow-ivar # (enabled by default)
++-Wshift-count-negative # (enabled by default)
++-Wshift-count-overflow # (enabled by default)
 +-Wsized-deallocation
-+-Wsizeof-array-argument
++-Wsizeof-array-argument # (enabled by default)
 +-Wsuggest-final-methods
 +-Wsuggest-final-types
 +-Wsuggest-override
-+-Wswitch-bool
++-Wswitch-bool # (enabled by default)
+--Wvariadic-macros # (enabled by default)
++-Wvariadic-macros

--- a/gcc/warnings-gcc-diff-5-6.txt
+++ b/gcc/warnings-gcc-diff-5-6.txt
@@ -1,24 +1,24 @@
 +-Wduplicated-cond
 +-Wframe-address
-+-Whsa
-+-Wignored-attributes
-+-Wlto-type-mismatch
++-Whsa # (enabled by default)
++-Wignored-attributes # (enabled by default)
++-Wlto-type-mismatch # (enabled by default)
 +-Wmisleading-indentation
 +-Wmultiple-inheritance
 +-Wnamespaces
 +-Wnonnull-compare
 +-Wnull-dereference
-+-Woverride-init-side-effects
++-Woverride-init-side-effects # (enabled by default)
 +-Wplacement-new
 +-Wplacement-new=
-+-Wscalar-storage-order
-+-Wshift-negative-value
++-Wscalar-storage-order # (enabled by default)
++-Wshift-negative-value # (enabled by default)
 +-Wshift-overflow
 +-Wshift-overflow=
-+-Wsubobject-linkage
++-Wsubobject-linkage # (enabled by default)
 +-Wtautological-compare
 +-Wtemplates
-+-Wterminate
++-Wterminate # (enabled by default)
 +-Wunused-const-variable
 +-Wunused-const-variable=
 +-Wvirtual-inheritance

--- a/gcc/warnings-gcc-top-level-4.0.txt
+++ b/gcc/warnings-gcc-top-level-4.0.txt
@@ -1,3 +1,16 @@
+# enabled by default:
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wimplicit-function-declaration
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmissing-field-initializers
+#    -Wnon-template-friend
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wprotocol
+#    -Wsign-compare
 -pedantic
 -Wabi
 -Waggregate-return
@@ -11,10 +24,7 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -28,26 +38,21 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Winvalid-offsetof
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wold-style-cast
@@ -56,17 +61,13 @@
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wprotocol
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
 -Wsign-promo
 -Wstrict-aliasing
 -Wstrict-aliasing=

--- a/gcc/warnings-gcc-top-level-4.1.txt
+++ b/gcc/warnings-gcc-top-level-4.1.txt
@@ -1,9 +1,25 @@
+# enabled by default:
+#    -Wattributes
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wimplicit-function-declaration
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmissing-field-initializers
+#    -Wnon-template-friend
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wprotocol
+#    -Wsign-compare
 -pedantic
 -Wabi
 -Waggregate-return
 -Wall
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wc++-compat
 -Wcast-align
@@ -14,10 +30,7 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -31,27 +44,21 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
@@ -61,19 +68,13 @@
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing

--- a/gcc/warnings-gcc-top-level-4.2.txt
+++ b/gcc/warnings-gcc-top-level-4.2.txt
@@ -1,10 +1,29 @@
+# enabled by default:
+#    -Wattributes
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wimplicit-function-declaration
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmissing-field-initializers
+#    -Wnon-template-friend
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wprotocol
+#    -Wsign-compare
 -pedantic
 -Wabi
 -Waddress
 -Waggregate-return
 -Wall
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wc++-compat
 -Wcast-align
@@ -15,10 +34,7 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -32,52 +48,37 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing

--- a/gcc/warnings-gcc-top-level-4.3.txt
+++ b/gcc/warnings-gcc-top-level-4.3.txt
@@ -1,3 +1,31 @@
+# enabled by default:
+#    -Wattributes
+#    -Wclobbered
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wempty-body
+#    -Wignored-qualifiers
+#    -Wimplicit-function-declaration
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmissing-field-initializers
+#    -Wmissing-parameter-type
+#    -Wnon-template-friend
+#    -Wold-style-declaration
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wprotocol
+#    -Wsign-compare
+#    -Wsign-conversion
+#    -Wtype-limits
+#    -Wvla
 -pedantic
 -Wabi
 -Waddress
@@ -5,26 +33,20 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wc++-compat
 -Wc++0x-compat
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
 -Wcomment
 -Wcomments
 -Wconversion
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
--Wempty-body
 -Wendif-labels
 -Werror-implicit-function-declaration
 -Wextra
@@ -37,58 +59,39 @@
 -Wformat-y2k
 -Wformat-zero-length
 -Wformat=
--Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
 -Wlarger-than-
 -Wlogical-op
--Wlong-long
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -106,7 +109,6 @@
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
 -Wundeclared-selector
 -Wundef
 -Wuninitialized
@@ -121,6 +123,5 @@
 -Wunused-value
 -Wunused-variable
 -Wvariadic-macros
--Wvla
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-top-level-4.4.txt
+++ b/gcc/warnings-gcc-top-level-4.4.txt
@@ -1,3 +1,42 @@
+# enabled by default:
+#    -Wattributes
+#    -Wclobbered
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wempty-body
+#    -Wenum-compare
+#    -Wignored-qualifiers
+#    -Wimplicit-function-declaration
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmain
+#    -Wmissing-field-initializers
+#    -Wmissing-parameter-type
+#    -Wmudflap
+#    -Wnon-template-friend
+#    -Wold-style-declaration
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wprotocol
+#    -Wpsabi
+#    -Wsign-compare
+#    -Wsign-conversion
+#    -Wsync-nand
+#    -Wtype-limits
+#    -Wunused-function
+#    -Wunused-label
+#    -Wunused-parameter
+#    -Wunused-value
+#    -Wunused-variable
+#    -Wvla
 -pedantic
 -Wabi
 -Waddress
@@ -5,7 +44,6 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -13,21 +51,15 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
 -Wcomment
 -Wcomments
 -Wconversion
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
--Wempty-body
 -Wendif-labels
--Wenum-compare
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -40,62 +72,39 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
 -Wmissing-prototypes
--Wmudflap
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
--Wpsabi
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -108,13 +117,11 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
 -Wundeclared-selector
 -Wundef
 -Wuninitialized
@@ -122,13 +129,7 @@
 -Wunreachable-code
 -Wunsafe-loop-optimizations
 -Wunused
--Wunused-function
--Wunused-label
 -Wunused-macros
--Wunused-parameter
--Wunused-value
--Wunused-variable
 -Wvariadic-macros
--Wvla
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-top-level-4.5.txt
+++ b/gcc/warnings-gcc-top-level-4.5.txt
@@ -1,3 +1,46 @@
+# enabled by default:
+#    -Wattributes
+#    -Wclobbered
+#    -Wconversion-null
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wempty-body
+#    -Wenum-compare
+#    -Wignored-qualifiers
+#    -Wimplicit-function-declaration
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wjump-misses-init
+#    -Wlong-long
+#    -Wmain
+#    -Wmissing-field-initializers
+#    -Wmissing-parameter-type
+#    -Wmudflap
+#    -Wnon-template-friend
+#    -Wold-style-declaration
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wprotocol
+#    -Wpsabi
+#    -Wsign-compare
+#    -Wsign-conversion
+#    -Wsync-nand
+#    -Wtype-limits
+#    -Wuninitialized
+#    -Wunused-function
+#    -Wunused-label
+#    -Wunused-parameter
+#    -Wunused-result
+#    -Wunused-value
+#    -Wunused-variable
+#    -Wvla
 -pedantic
 -Wabi
 -Waddress
@@ -5,7 +48,6 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -13,22 +55,15 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
 -Wcomment
 -Wcomments
 -Wconversion
--Wconversion-null
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Weffc++
--Wempty-body
 -Wendif-labels
--Wenum-compare
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -41,63 +76,39 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
--Wjump-misses-init
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
 -Wmissing-prototypes
--Wmudflap
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
--Wpsabi
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -110,29 +121,19 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
 -Wundeclared-selector
 -Wundef
--Wuninitialized
 -Wunknown-pragmas
 -Wunreachable-code
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-function
--Wunused-label
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
 -Wvariadic-macros
--Wvla
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-top-level-4.6.txt
+++ b/gcc/warnings-gcc-top-level-4.6.txt
@@ -1,3 +1,53 @@
+# enabled by default:
+#    -Wattributes
+#    -Wclobbered
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wempty-body
+#    -Wenum-compare
+#    -Wignored-qualifiers
+#    -Wimplicit
+#    -Wimplicit-function-declaration
+#    -Wimplicit-int
+#    -Wint-to-pointer-cast
+#    -Winvalid-offsetof
+#    -Wjump-misses-init
+#    -Wlong-long
+#    -Wmain
+#    -Wmissing-field-initializers
+#    -Wmissing-parameter-type
+#    -Wmudflap
+#    -Wnon-template-friend
+#    -Wold-style-declaration
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wsign-compare
+#    -Wsign-conversion
+#    -Wsync-nand
+#    -Wtype-limits
+#    -Wuninitialized
+#    -Wunused-but-set-parameter
+#    -Wunused-but-set-variable
+#    -Wunused-function
+#    -Wunused-label
+#    -Wunused-parameter
+#    -Wunused-result
+#    -Wunused-value
+#    -Wunused-variable
+#    -Wvla
 -pedantic
 -Wabi
 -Waddress
@@ -5,7 +55,6 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -13,23 +62,14 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
 -Wcomment
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Wdouble-promotion
 -Weffc++
--Wempty-body
 -Wendif-labels
--Wenum-compare
 -Wextra
 -Wfloat-equal
 -Wformat
@@ -41,64 +81,37 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
--Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
 -Wimport # DUMMY switch
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
 -Winvalid-pch
--Wjump-misses-init
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
 -Wmissing-prototypes
--Wmudflap
 -Wmultichar
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -114,32 +127,20 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrampolines
 -Wtrigraphs
--Wtype-limits
 -Wundeclared-selector
 -Wundef
--Wuninitialized
 -Wunknown-pragmas
 -Wunreachable-code # DUMMY switch
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-but-set-parameter
--Wunused-but-set-variable
--Wunused-function
--Wunused-label
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
 -Wvariadic-macros
--Wvla
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-top-level-4.7.txt
+++ b/gcc/warnings-gcc-top-level-4.7.txt
@@ -1,3 +1,56 @@
+# enabled by default:
+#    -Wattributes
+#    -Wclobbered
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wempty-body
+#    -Wenum-compare
+#    -Wfree-nonheap-object
+#    -Wignored-qualifiers
+#    -Wimplicit
+#    -Wimplicit-function-declaration
+#    -Wimplicit-int
+#    -Wint-to-pointer-cast
+#    -Winvalid-memory-model
+#    -Winvalid-offsetof
+#    -Wjump-misses-init
+#    -Wlong-long
+#    -Wmain
+#    -Wmissing-field-initializers
+#    -Wmissing-parameter-type
+#    -Wmudflap
+#    -Wnarrowing
+#    -Wnon-template-friend
+#    -Wold-style-declaration
+#    -Woverflow
+#    -Woverlength-strings
+#    -Woverride-init
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-sign
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wsign-compare
+#    -Wsign-conversion
+#    -Wsync-nand
+#    -Wtype-limits
+#    -Wuninitialized
+#    -Wunused-but-set-parameter
+#    -Wunused-but-set-variable
+#    -Wunused-function
+#    -Wunused-label
+#    -Wunused-parameter
+#    -Wunused-result
+#    -Wunused-value
+#    -Wunused-variable
+#    -Wvla
 -pedantic
 -Wabi
 -Waddress
@@ -5,7 +58,6 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -13,24 +65,15 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
 -Wcomment
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Wdouble-promotion
 -Weffc++
--Wempty-body
 -Wendif-labels
--Wenum-compare
 -Wextra
 -Wfloat-equal
 -Wformat
@@ -42,68 +85,38 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wfree-nonheap-object
--Wignored-qualifiers
--Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
 -Wimport # DUMMY switch
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
 -Winvalid-pch
--Wjump-misses-init
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
 -Wmaybe-uninitialized
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
 -Wmissing-prototypes
--Wmudflap
 -Wmultichar
--Wnarrowing
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
 -Wold-style-definition
--Woverflow
--Woverlength-strings
 -Woverloaded-virtual
--Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wparentheses
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
 -Wsign-promo
 -Wstack-protector
 -Wstack-usage=
@@ -120,35 +133,23 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrampolines
 -Wtrigraphs
--Wtype-limits
 -Wundeclared-selector
 -Wundef
--Wuninitialized
 -Wunknown-pragmas
 -Wunreachable-code # DUMMY switch
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-but-set-parameter
--Wunused-but-set-variable
--Wunused-function
--Wunused-label
 -Wunused-local-typedefs
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
 -Wvariadic-macros
 -Wvector-operation-performance
--Wvla
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-top-level-4.8.txt
+++ b/gcc/warnings-gcc-top-level-4.8.txt
@@ -1,7 +1,42 @@
+# enabled by default:
+#    -Waggressive-loop-optimizations
+#    -Wattributes
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wenum-compare
+#    -Wfree-nonheap-object
+#    -Wimplicit-function-declaration
+#    -Winherited-variadic-ctor
+#    -Wint-to-pointer-cast
+#    -Winvalid-memory-model
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmain
+#    -Wmudflap
+#    -Wnarrowing
+#    -Wnon-template-friend
+#    -Woverflow
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wreturn-local-addr
+#    -Wsync-nand
+#    -Wunused-result
+#    -Wvarargs
+#    -Wvariadic-macros
+#    -Wvirtual-move-assign
+#    -Wvla
 -Wabi
 -Wabi-tag
 -Waggregate-return
--Waggressive-loop-optimizations
 -Wall
 #    -Waddress
 #    -Warray-bounds
@@ -49,7 +84,6 @@
 #      -Wunused-variable
 #    -Wvolatile-register-var
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -59,15 +93,9 @@
 -Wcomment
 -Wconversion
 #    -Wsign-conversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Wdouble-promotion
 -Weffc++
 #    -Wdelete-non-virtual-dtor
@@ -88,49 +116,32 @@
 #    -Wunused-parameter
 -Wfloat-equal
 -Wframe-larger-than=
--Wfree-nonheap-object
 -Wimport # DUMMY switch
--Winherited-variadic-ctor
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than=
 -Wliteral-suffix
 -Wlogical-op
--Wlong-long
 -Wmissing-declarations
 -Wmissing-include-dirs
 -Wmissing-prototypes
--Wmudflap
 -Wmultichar
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnon-virtual-dtor
 -Wnormalized=
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
 -Woverloaded-virtual
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wpedantic
 #    -Wmain
 #    -Woverlength-strings
 #    -Wpointer-sign
--Wpmf-conversions
 -Wpointer-arith
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
 -Wredundant-decls
--Wreturn-local-addr
 -Wselector
 -Wshadow
 -Wsign-promo
@@ -147,7 +158,6 @@
 -Wsuggest-attribute=pure
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -160,12 +170,7 @@
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused-macros
--Wunused-result
 -Wuseless-cast
--Wvarargs
--Wvariadic-macros
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-top-level-4.9.txt
+++ b/gcc/warnings-gcc-top-level-4.9.txt
@@ -1,7 +1,42 @@
+# enabled by default:
+#    -Waggressive-loop-optimizations
+#    -Wattributes
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdelete-incomplete
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdiv-by-zero
+#    -Wenum-compare
+#    -Wfree-nonheap-object
+#    -Wimplicit-function-declaration
+#    -Winherited-variadic-ctor
+#    -Wint-to-pointer-cast
+#    -Winvalid-memory-model
+#    -Winvalid-offsetof
+#    -Wlong-long
+#    -Wmain
+#    -Wnarrowing
+#    -Wnon-template-friend
+#    -Woverflow
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wreturn-local-addr
+#    -Wsync-nand
+#    -Wunused-result
+#    -Wvarargs
+#    -Wvariadic-macros
+#    -Wvirtual-move-assign
+#    -Wvla
 -Wabi
 -Wabi-tag
 -Waggregate-return
--Waggressive-loop-optimizations
 -Wall
 #    -Waddress
 #    -Warray-bounds
@@ -50,7 +85,6 @@
 #      -Wunused-variable
 #    -Wvolatile-register-var
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -62,17 +96,10 @@
 -Wconversion
 #    -Wfloat-conversion
 #    -Wsign-conversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdate-time
 -Wdeclaration-after-statement
--Wdelete-incomplete
--Wdeprecated
--Wdeprecated-declarations
 -Wdisabled-optimization
--Wdiv-by-zero
 -Wdouble-promotion
 -Weffc++
 #    -Wdelete-non-virtual-dtor
@@ -94,19 +121,13 @@
 #    -Wunused-parameter
 -Wfloat-equal
 -Wframe-larger-than=
--Wfree-nonheap-object
 -Wimport # DUMMY switch
--Winherited-variadic-ctor
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than=
 -Wliteral-suffix
 -Wlogical-op
--Wlong-long
 -Wmissing-declarations
 -Wmissing-include-dirs
 -Wmissing-prototypes
@@ -114,28 +135,18 @@
 -Wmultichar
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnormalized=
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
 -Woverloaded-virtual
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wpedantic
 #    -Wmain
 #    -Woverlength-strings
 #    -Wpointer-arith
 #    -Wpointer-sign
--Wpmf-conversions
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
 -Wredundant-decls
--Wreturn-local-addr
 -Wselector
 -Wshadow
 -Wsign-promo
@@ -152,7 +163,6 @@
 -Wsuggest-attribute=pure
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -165,12 +175,7 @@
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused-macros
--Wunused-result
 -Wuseless-cast
--Wvarargs
--Wvariadic-macros
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-top-level-5.txt
+++ b/gcc/warnings-gcc-top-level-5.txt
@@ -1,9 +1,62 @@
+# enabled by default:
+#    -Waggressive-loop-optimizations
+#    -Wattributes
+#    -Wbuiltin-macro-redefined
+#    -Wc90-c99-compat
+#      -Wlong-long
+#    -Wc99-c11-compat
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdeclaration-after-statement
+#    -Wdelete-incomplete
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdesignated-init
+#    -Wdiscarded-array-qualifiers
+#    -Wdiscarded-qualifiers
+#    -Wdiv-by-zero
+#    -Wendif-labels
+#    -Wenum-compare
+#    -Wfree-nonheap-object
+#    -Wimplicit-function-declaration
+#    -Wimplicit-int
+#    -Wincompatible-pointer-types
+#    -Winherited-variadic-ctor
+#    -Wint-conversion
+#    -Wint-to-pointer-cast
+#    -Winvalid-memory-model
+#    -Winvalid-offsetof
+#    -Wliteral-suffix
+#    -Wlong-long
+#    -Wmain
+#    -Wnarrowing
+#    -Wnon-template-friend
+#    -Wodr
+#    -Woverflow
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wreturn-local-addr
+#    -Wshadow-ivar
+#    -Wshift-count-negative
+#    -Wshift-count-overflow
+#    -Wsizeof-array-argument
+#    -Wswitch-bool
+#    -Wsync-nand
+#    -Wunused-result
+#    -Wvarargs
+#    -Wvirtual-move-assign
+#    -Wvla
 -Wabi
 #    -Wpsabi
 -Wabi-tag
 -Wabi=
 -Waggregate-return
--Waggressive-loop-optimizations
 -Wall
 #    -Waddress
 #    -Warray-bounds
@@ -60,34 +113,18 @@
 #      -Wunused-variable
 #    -Wvolatile-register-var
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
--Wbuiltin-macro-redefined
 -Wc++-compat
 #    -Wenum-compare
--Wc90-c99-compat
-#    -Wlong-long
--Wc99-c11-compat
 -Wcast-align
 -Wcast-qual
 -Wconditionally-supported
 -Wconversion
 #    -Wfloat-conversion
 #    -Wsign-conversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdate-time
--Wdeclaration-after-statement
--Wdelete-incomplete
--Wdeprecated
--Wdeprecated-declarations
--Wdesignated-init
 -Wdisabled-optimization
--Wdiscarded-array-qualifiers
--Wdiscarded-qualifiers
--Wdiv-by-zero
 -Wdouble-promotion
 -Weffc++
 #    -Wdelete-non-virtual-dtor
@@ -110,19 +147,11 @@
 -Wfloat-equal
 -Wformat-signedness
 -Wframe-larger-than=
--Wfree-nonheap-object
 -Wimport # DUMMY switch
--Wincompatible-pointer-types
--Winherited-variadic-ctor
 -Winline
--Wint-conversion
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than=
--Wliteral-suffix
 -Wlogical-op
 -Wmissing-declarations
 -Wmissing-include-dirs
@@ -131,15 +160,11 @@
 -Wmultichar
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnormalized=
--Wodr
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
 -Woverloaded-virtual
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wpedantic
 #    -Wendif-labels
@@ -148,20 +173,11 @@
 #    -Wpointer-arith
 #    -Wpointer-sign
 #    -Wvariadic-macros
--Wpmf-conversions
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
 -Wredundant-decls
--Wreturn-local-addr
 -Wselector
 -Wshadow
 #    -Wshadow-ivar
--Wshift-count-negative
--Wshift-count-overflow
 -Wsign-promo
--Wsizeof-array-argument
 -Wstack-protector
 -Wstack-usage=
 -Wstrict-aliasing
@@ -176,10 +192,8 @@
 -Wsuggest-final-methods
 -Wsuggest-final-types
 -Wsuggest-override
--Wswitch-bool
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -192,11 +206,7 @@
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused-macros
--Wunused-result
 -Wuseless-cast
--Wvarargs
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-top-level-6.txt
+++ b/gcc/warnings-gcc-top-level-6.txt
@@ -1,9 +1,70 @@
+# enabled by default:
+#    -Waggressive-loop-optimizations
+#    -Wattributes
+#    -Wbuiltin-macro-redefined
+#    -Wc90-c99-compat
+#      -Wlong-long
+#    -Wc99-c11-compat
+#    -Wconversion-null
+#    -Wcoverage-mismatch
+#    -Wcpp
+#    -Wdeclaration-after-statement
+#    -Wdelete-incomplete
+#    -Wdeprecated
+#    -Wdeprecated-declarations
+#    -Wdesignated-init
+#    -Wdiscarded-array-qualifiers
+#    -Wdiscarded-qualifiers
+#    -Wdiv-by-zero
+#    -Wendif-labels
+#    -Wenum-compare
+#    -Wfree-nonheap-object
+#    -Whsa
+#    -Wignored-attributes
+#    -Wimplicit-function-declaration
+#    -Wimplicit-int
+#    -Wincompatible-pointer-types
+#    -Winherited-variadic-ctor
+#    -Wint-conversion
+#    -Wint-to-pointer-cast
+#    -Winvalid-memory-model
+#    -Winvalid-offsetof
+#    -Wliteral-suffix
+#    -Wlong-long
+#    -Wlto-type-mismatch
+#    -Wmain
+#    -Wnarrowing
+#    -Wnon-template-friend
+#    -Wodr
+#    -Woverflow
+#    -Woverride-init-side-effects
+#    -Wpacked-bitfield-compat
+#    -Wpmf-conversions
+#    -Wpointer-to-int-cast
+#    -Wpragmas
+#    -Wproperty-assign-default
+#    -Wprotocol
+#    -Wpsabi
+#    -Wreturn-local-addr
+#    -Wscalar-storage-order
+#    -Wshadow-ivar
+#    -Wshift-count-negative
+#    -Wshift-count-overflow
+#    -Wshift-negative-value
+#    -Wsizeof-array-argument
+#    -Wsubobject-linkage
+#    -Wswitch-bool
+#    -Wsync-nand
+#    -Wterminate
+#    -Wunused-result
+#    -Wvarargs
+#    -Wvirtual-move-assign
+#    -Wvla
 -Wabi
 #    -Wpsabi
 -Wabi-tag
 -Wabi=
 -Waggregate-return
--Waggressive-loop-optimizations
 -Wall
 #    -Waddress
 #    -Warray-bounds
@@ -65,34 +126,18 @@
 #        -Wunused-const-variable=
 #    -Wvolatile-register-var
 -Wassign-intercept
--Wattributes
 -Wbad-function-cast
--Wbuiltin-macro-redefined
 -Wc++-compat
 #    -Wenum-compare
--Wc90-c99-compat
-#    -Wlong-long
--Wc99-c11-compat
 -Wcast-align
 -Wcast-qual
 -Wconditionally-supported
 -Wconversion
 #    -Wfloat-conversion
 #    -Wsign-conversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
 -Wctor-dtor-privacy
 -Wdate-time
--Wdeclaration-after-statement
--Wdelete-incomplete
--Wdeprecated
--Wdeprecated-declarations
--Wdesignated-init
 -Wdisabled-optimization
--Wdiscarded-array-qualifiers
--Wdiscarded-qualifiers
--Wdiv-by-zero
 -Wdouble-promotion
 -Wduplicated-cond
 -Weffc++
@@ -116,23 +161,12 @@
 -Wfloat-equal
 -Wformat-signedness
 -Wframe-larger-than=
--Wfree-nonheap-object
--Whsa
--Wignored-attributes
 -Wimport # DUMMY switch
--Wincompatible-pointer-types
--Winherited-variadic-ctor
 -Winline
--Wint-conversion
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than=
--Wliteral-suffix
 -Wlogical-op
--Wlto-type-mismatch
 -Wmissing-declarations
 -Wmissing-include-dirs
 -Wmissing-prototypes
@@ -142,17 +176,12 @@
 -Wnamespaces
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
 -Wnormalized=
 -Wnull-dereference
--Wodr
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
 -Woverloaded-virtual
--Woverride-init-side-effects
 -Wpacked
--Wpacked-bitfield-compat
 -Wpadded
 -Wpedantic
 #    -Wendif-labels
@@ -162,23 +191,12 @@
 #    -Wpointer-sign
 #    -Wvariadic-macros
 -Wplacement-new=
--Wpmf-conversions
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
 -Wredundant-decls
--Wreturn-local-addr
--Wscalar-storage-order
 -Wselector
 -Wshadow
 #    -Wshadow-ivar
--Wshift-count-negative
--Wshift-count-overflow
--Wshift-negative-value
 -Wshift-overflow=
 -Wsign-promo
--Wsizeof-array-argument
 -Wstack-protector
 -Wstack-usage=
 -Wstrict-aliasing
@@ -186,7 +204,6 @@
 -Wstrict-overflow
 -Wstrict-prototypes
 -Wstrict-selector-match
--Wsubobject-linkage
 -Wsuggest-attribute=const
 -Wsuggest-attribute=format
 -Wsuggest-attribute=noreturn
@@ -194,14 +211,11 @@
 -Wsuggest-final-methods
 -Wsuggest-final-types
 -Wsuggest-override
--Wswitch-bool
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
 -Wsynth
 -Wsystem-headers
 -Wtemplates
--Wterminate
 -Wtraditional
 #    -Wvariadic-macros
 -Wtraditional-conversion
@@ -212,12 +226,8 @@
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused-macros
--Wunused-result
 -Wuseless-cast
--Wvarargs
 -Wvector-operation-performance
 -Wvirtual-inheritance
--Wvirtual-move-assign
--Wvla
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-unique-4.0.txt
+++ b/gcc/warnings-gcc-unique-4.0.txt
@@ -15,10 +15,10 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -32,26 +32,26 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Winvalid-offsetof
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
+-Wlong-long # (enabled by default)
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wold-style-cast
@@ -60,17 +60,17 @@
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wprotocol
+-Wpointer-sign # (enabled by default)
+-Wprotocol # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
+-Wsign-compare # (enabled by default)
 -Wsign-promo
 -Wstrict-aliasing
 -Wstrict-aliasing=

--- a/gcc/warnings-gcc-unique-4.1.txt
+++ b/gcc/warnings-gcc-unique-4.1.txt
@@ -7,7 +7,7 @@
 -Waggregate-return
 -Wall
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wc++-compat
 -Wcast-align
@@ -18,10 +18,10 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -35,27 +35,27 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
+-Wlong-long # (enabled by default)
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
@@ -65,19 +65,19 @@
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wprotocol # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
+-Wsign-compare # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing

--- a/gcc/warnings-gcc-unique-4.2.txt
+++ b/gcc/warnings-gcc-unique-4.2.txt
@@ -8,7 +8,7 @@
 -Waggregate-return
 -Wall
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wc++-compat
 -Wcast-align
@@ -19,10 +19,10 @@
 -Wconversion
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
 -Wendif-labels
 -Werror-implicit-function-declaration
@@ -36,52 +36,52 @@
 -Wformat-zero-length
 -Wformat=
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wlarger-than-
--Wlong-long
+-Wlong-long # (enabled by default)
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wprotocol # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
+-Wsign-compare # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing

--- a/gcc/warnings-gcc-unique-4.3.txt
+++ b/gcc/warnings-gcc-unique-4.3.txt
@@ -9,26 +9,26 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wc++-compat
 -Wc++0x-compat
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
+-Wclobbered # (enabled by default)
 -Wcomment
 -Wcomments
 -Wconversion
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
--Wempty-body
+-Wempty-body # (enabled by default)
 -Wendif-labels
 -Werror-implicit-function-declaration
 -Wextra
@@ -41,58 +41,58 @@
 -Wformat-y2k
 -Wformat-zero-length
 -Wformat=
--Wignored-qualifiers
+-Wignored-qualifiers # (enabled by default)
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wlarger-than-
 -Wlogical-op
--Wlong-long
+-Wlong-long # (enabled by default)
 -Wmain
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
+-Wmissing-parameter-type # (enabled by default)
 -Wmissing-prototypes
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
+-Wold-style-declaration # (enabled by default)
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wprotocol # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
+-Wsign-compare # (enabled by default)
+-Wsign-conversion # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -110,7 +110,7 @@
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
+-Wtype-limits # (enabled by default)
 -Wundeclared-selector
 -Wundef
 -Wuninitialized
@@ -125,6 +125,6 @@
 -Wunused-value
 -Wunused-variable
 -Wvariadic-macros
--Wvla
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-unique-4.4.txt
+++ b/gcc/warnings-gcc-unique-4.4.txt
@@ -9,7 +9,7 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -17,21 +17,21 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
+-Wclobbered # (enabled by default)
 -Wcomment
 -Wcomments
 -Wconversion
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
--Wempty-body
+-Wempty-body # (enabled by default)
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -44,62 +44,62 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
+-Wignored-qualifiers # (enabled by default)
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
+-Wmissing-parameter-type # (enabled by default)
 -Wmissing-prototypes
--Wmudflap
+-Wmudflap # (enabled by default)
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
+-Wold-style-declaration # (enabled by default)
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
--Wpsabi
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
+-Wsign-compare # (enabled by default)
+-Wsign-conversion # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -112,13 +112,13 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
+-Wtype-limits # (enabled by default)
 -Wundeclared-selector
 -Wundef
 -Wuninitialized
@@ -126,13 +126,13 @@
 -Wunreachable-code
 -Wunsafe-loop-optimizations
 -Wunused
--Wunused-function
--Wunused-label
+-Wunused-function # (enabled by default)
+-Wunused-label # (enabled by default)
 -Wunused-macros
--Wunused-parameter
--Wunused-value
--Wunused-variable
+-Wunused-parameter # (enabled by default)
+-Wunused-value # (enabled by default)
+-Wunused-variable # (enabled by default)
 -Wvariadic-macros
--Wvla
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-unique-4.5.txt
+++ b/gcc/warnings-gcc-unique-4.5.txt
@@ -9,7 +9,7 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -17,22 +17,22 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
+-Wclobbered # (enabled by default)
 -Wcomment
 -Wcomments
 -Wconversion
--Wconversion-null
+-Wconversion-null # (enabled by default)
 -Wcoverage-mismatch
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Weffc++
--Wempty-body
+-Wempty-body # (enabled by default)
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -45,63 +45,63 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
+-Wignored-qualifiers # (enabled by default)
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
--Wjump-misses-init
+-Wjump-misses-init # (enabled by default)
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
+-Wmissing-parameter-type # (enabled by default)
 -Wmissing-prototypes
--Wmudflap
+-Wmudflap # (enabled by default)
 -Wmultichar
 -Wnested-externs
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
+-Wold-style-declaration # (enabled by default)
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wprotocol
--Wpsabi
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
+-Wsign-compare # (enabled by default)
+-Wsign-conversion # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -114,29 +114,29 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrigraphs
--Wtype-limits
+-Wtype-limits # (enabled by default)
 -Wundeclared-selector
 -Wundef
--Wuninitialized
+-Wuninitialized # (enabled by default)
 -Wunknown-pragmas
 -Wunreachable-code
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-function
--Wunused-label
+-Wunused-function # (enabled by default)
+-Wunused-label # (enabled by default)
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
+-Wunused-parameter # (enabled by default)
+-Wunused-result # (enabled by default)
+-Wunused-value # (enabled by default)
+-Wunused-variable # (enabled by default)
 -Wvariadic-macros
--Wvla
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-unique-4.6.txt
+++ b/gcc/warnings-gcc-unique-4.6.txt
@@ -9,7 +9,7 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -17,24 +17,24 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
+-Wclobbered # (enabled by default)
 -Wcomment
 -Wcomments
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Weffc++
--Wempty-body
+-Wempty-body # (enabled by default)
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -47,65 +47,65 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wignored-qualifiers
--Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
+-Wignored-qualifiers # (enabled by default)
+-Wimplicit # (enabled by default)
+-Wimplicit-function-declaration # (enabled by default)
+-Wimplicit-int # (enabled by default)
 -Wimport # DUMMY switch
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
--Wjump-misses-init
+-Wjump-misses-init # (enabled by default)
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
+-Wmissing-parameter-type # (enabled by default)
 -Wmissing-prototypes
--Wmudflap
+-Wmudflap # (enabled by default)
 -Wmultichar
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
+-Wold-style-declaration # (enabled by default)
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
+-Wsign-compare # (enabled by default)
+-Wsign-conversion # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstrict-aliasing
@@ -121,32 +121,32 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrampolines
 -Wtrigraphs
--Wtype-limits
+-Wtype-limits # (enabled by default)
 -Wundeclared-selector
 -Wundef
--Wuninitialized
+-Wuninitialized # (enabled by default)
 -Wunknown-pragmas
 -Wunreachable-code # DUMMY switch
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-but-set-parameter
--Wunused-but-set-variable
--Wunused-function
--Wunused-label
+-Wunused-but-set-parameter # (enabled by default)
+-Wunused-but-set-variable # (enabled by default)
+-Wunused-function # (enabled by default)
+-Wunused-label # (enabled by default)
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
+-Wunused-parameter # (enabled by default)
+-Wunused-result # (enabled by default)
+-Wunused-value # (enabled by default)
+-Wunused-variable # (enabled by default)
 -Wvariadic-macros
--Wvla
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings

--- a/gcc/warnings-gcc-unique-4.7.txt
+++ b/gcc/warnings-gcc-unique-4.7.txt
@@ -9,7 +9,7 @@
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -18,25 +18,25 @@
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
--Wclobbered
+-Wclobbered # (enabled by default)
 -Wcomment
 -Wcomments
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Weffc++
--Wempty-body
+-Wempty-body # (enabled by default)
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -49,69 +49,69 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wfree-nonheap-object
--Wignored-qualifiers
--Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
+-Wfree-nonheap-object # (enabled by default)
+-Wignored-qualifiers # (enabled by default)
+-Wimplicit # (enabled by default)
+-Wimplicit-function-declaration # (enabled by default)
+-Wimplicit-int # (enabled by default)
 -Wimport # DUMMY switch
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-memory-model # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
--Wjump-misses-init
+-Wjump-misses-init # (enabled by default)
 -Wlarger-than-
 -Wlarger-than=
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmaybe-uninitialized
 -Wmissing-braces
 -Wmissing-declarations
--Wmissing-field-initializers
+-Wmissing-field-initializers # (enabled by default)
 -Wmissing-format-attribute
 -Wmissing-include-dirs
 -Wmissing-noreturn
--Wmissing-parameter-type
+-Wmissing-parameter-type # (enabled by default)
 -Wmissing-prototypes
--Wmudflap
+-Wmudflap # (enabled by default)
 -Wmultichar
--Wnarrowing
+-Wnarrowing # (enabled by default)
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
--Wold-style-declaration
+-Wold-style-declaration # (enabled by default)
 -Wold-style-definition
--Woverflow
--Woverlength-strings
+-Woverflow # (enabled by default)
+-Woverlength-strings # (enabled by default)
 -Woverloaded-virtual
--Woverride-init
+-Woverride-init # (enabled by default)
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
--Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-sign # (enabled by default)
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wsign-compare
--Wsign-conversion
+-Wsign-compare # (enabled by default)
+-Wsign-conversion # (enabled by default)
 -Wsign-promo
 -Wstack-protector
 -Wstack-usage=
@@ -128,35 +128,35 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
 -Wtraditional-conversion
 -Wtrampolines
 -Wtrigraphs
--Wtype-limits
+-Wtype-limits # (enabled by default)
 -Wundeclared-selector
 -Wundef
--Wuninitialized
+-Wuninitialized # (enabled by default)
 -Wunknown-pragmas
 -Wunreachable-code # DUMMY switch
 -Wunsafe-loop-optimizations
 -Wunsuffixed-float-constants
 -Wunused
--Wunused-but-set-parameter
--Wunused-but-set-variable
--Wunused-function
--Wunused-label
+-Wunused-but-set-parameter # (enabled by default)
+-Wunused-but-set-variable # (enabled by default)
+-Wunused-function # (enabled by default)
+-Wunused-label # (enabled by default)
 -Wunused-local-typedefs
 -Wunused-macros
--Wunused-parameter
--Wunused-result
--Wunused-value
--Wunused-variable
+-Wunused-parameter # (enabled by default)
+-Wunused-result # (enabled by default)
+-Wunused-value # (enabled by default)
+-Wunused-variable # (enabled by default)
 -Wvariadic-macros
 -Wvector-operation-performance
--Wvla
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-unique-4.8.txt
+++ b/gcc/warnings-gcc-unique-4.8.txt
@@ -7,11 +7,11 @@
 -Wabi-tag
 -Waddress
 -Waggregate-return
--Waggressive-loop-optimizations
+-Waggressive-loop-optimizations # (enabled by default)
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -24,21 +24,21 @@
 -Wcomment
 -Wcomments
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdeclaration-after-statement
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Weffc++
 -Wempty-body
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-equal
@@ -51,26 +51,26 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wfree-nonheap-object
+-Wfree-nonheap-object # (enabled by default)
 -Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport # DUMMY switch
--Winherited-variadic-ctor
+-Winherited-variadic-ctor # (enabled by default)
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-memory-model # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than-
 -Wlarger-than=
 -Wliteral-suffix
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmaybe-uninitialized
 -Wmissing-braces
 -Wmissing-declarations
@@ -80,38 +80,38 @@
 -Wmissing-noreturn
 -Wmissing-parameter-type
 -Wmissing-prototypes
--Wmudflap
+-Wmudflap # (enabled by default)
 -Wmultichar
--Wnarrowing
+-Wnarrowing # (enabled by default)
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
 -Wold-style-cast
 -Wold-style-declaration
 -Wold-style-definition
--Woverflow
+-Woverflow # (enabled by default)
 -Woverlength-strings
 -Woverloaded-virtual
 -Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
 -Wpedantic
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
 -Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
--Wreturn-local-addr
+-Wreturn-local-addr # (enabled by default)
 -Wreturn-type
 -Wselector
 -Wsequence-point
@@ -136,7 +136,7 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -159,15 +159,15 @@
 -Wunused-local-typedefs
 -Wunused-macros
 -Wunused-parameter
--Wunused-result
+-Wunused-result # (enabled by default)
 -Wunused-value
 -Wunused-variable
 -Wuseless-cast
--Wvarargs
--Wvariadic-macros
+-Wvarargs # (enabled by default)
+-Wvariadic-macros # (enabled by default)
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
+-Wvirtual-move-assign # (enabled by default)
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-unique-4.9.txt
+++ b/gcc/warnings-gcc-unique-4.9.txt
@@ -7,11 +7,11 @@
 -Wabi-tag
 -Waddress
 -Waggregate-return
--Waggressive-loop-optimizations
+-Waggressive-loop-optimizations # (enabled by default)
 -Wall
 -Warray-bounds
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbuiltin-macro-redefined
 -Wc++-compat
@@ -25,23 +25,23 @@
 -Wcomments
 -Wconditionally-supported
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdate-time
 -Wdeclaration-after-statement
--Wdelete-incomplete
+-Wdelete-incomplete # (enabled by default)
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
 -Wdisabled-optimization
--Wdiv-by-zero
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Weffc++
 -Wempty-body
 -Wendif-labels
--Wenum-compare
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-conversion
@@ -55,26 +55,26 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wfree-nonheap-object
+-Wfree-nonheap-object # (enabled by default)
 -Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
+-Wimplicit-function-declaration # (enabled by default)
 -Wimplicit-int
 -Wimport # DUMMY switch
--Winherited-variadic-ctor
+-Winherited-variadic-ctor # (enabled by default)
 -Winit-self
 -Winline
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-memory-model # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than-
 -Wlarger-than=
 -Wliteral-suffix
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmaybe-uninitialized
 -Wmissing-braces
 -Wmissing-declarations
@@ -86,10 +86,10 @@
 -Wmissing-prototypes
 -Wmudflap # DUMMY switch
 -Wmultichar
--Wnarrowing
+-Wnarrowing # (enabled by default)
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized=
@@ -97,26 +97,26 @@
 -Wold-style-declaration
 -Wold-style-definition
 -Wopenmp-simd
--Woverflow
+-Woverflow # (enabled by default)
 -Woverlength-strings
 -Woverloaded-virtual
 -Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
 -Wpedantic
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
 -Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
--Wreturn-local-addr
+-Wreturn-local-addr # (enabled by default)
 -Wreturn-type
 -Wselector
 -Wsequence-point
@@ -141,7 +141,7 @@
 -Wswitch
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -164,15 +164,15 @@
 -Wunused-local-typedefs
 -Wunused-macros
 -Wunused-parameter
--Wunused-result
+-Wunused-result # (enabled by default)
 -Wunused-value
 -Wunused-variable
 -Wuseless-cast
--Wvarargs
--Wvariadic-macros
+-Wvarargs # (enabled by default)
+-Wvariadic-macros # (enabled by default)
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
+-Wvirtual-move-assign # (enabled by default)
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-unique-5.txt
+++ b/gcc/warnings-gcc-unique-5.txt
@@ -8,21 +8,21 @@
 -Wabi=
 -Waddress
 -Waggregate-return
--Waggressive-loop-optimizations
+-Waggressive-loop-optimizations # (enabled by default)
 -Wall
 -Warray-bounds
 -Warray-bounds=
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbool-compare
--Wbuiltin-macro-redefined
+-Wbuiltin-macro-redefined # (enabled by default)
 -Wc++-compat
 -Wc++0x-compat
 -Wc++11-compat
 -Wc++14-compat
--Wc90-c99-compat
--Wc99-c11-compat
+-Wc90-c99-compat # (enabled by default)
+-Wc99-c11-compat # (enabled by default)
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
@@ -32,26 +32,26 @@
 -Wcomments
 -Wconditionally-supported
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdate-time
--Wdeclaration-after-statement
--Wdelete-incomplete
+-Wdeclaration-after-statement # (enabled by default)
+-Wdelete-incomplete # (enabled by default)
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
--Wdesignated-init
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
+-Wdesignated-init # (enabled by default)
 -Wdisabled-optimization
--Wdiscarded-array-qualifiers
--Wdiscarded-qualifiers
--Wdiv-by-zero
+-Wdiscarded-array-qualifiers # (enabled by default)
+-Wdiscarded-qualifiers # (enabled by default)
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Weffc++
 -Wempty-body
--Wendif-labels
--Wenum-compare
+-Wendif-labels # (enabled by default)
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-conversion
@@ -66,29 +66,29 @@
 -Wformat-zero-length
 -Wformat=
 -Wframe-larger-than=
--Wfree-nonheap-object
+-Wfree-nonheap-object # (enabled by default)
 -Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
+-Wimplicit-function-declaration # (enabled by default)
+-Wimplicit-int # (enabled by default)
 -Wimport # DUMMY switch
--Wincompatible-pointer-types
--Winherited-variadic-ctor
+-Wincompatible-pointer-types # (enabled by default)
+-Winherited-variadic-ctor # (enabled by default)
 -Winit-self
 -Winline
--Wint-conversion
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
+-Wint-conversion # (enabled by default)
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-memory-model # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than-
 -Wlarger-than=
--Wliteral-suffix
+-Wliteral-suffix # (enabled by default)
 -Wlogical-not-parentheses
 -Wlogical-op
--Wlong-long
--Wmain
+-Wlong-long # (enabled by default)
+-Wmain # (enabled by default)
 -Wmaybe-uninitialized
 -Wmemset-transposed-args
 -Wmissing-braces
@@ -101,51 +101,51 @@
 -Wmissing-prototypes
 -Wmudflap # DUMMY switch
 -Wmultichar
--Wnarrowing
+-Wnarrowing # (enabled by default)
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnormalized
 -Wnormalized=
--Wodr
+-Wodr # (enabled by default)
 -Wold-style-cast
 -Wold-style-declaration
 -Wold-style-definition
 -Wopenmp-simd
--Woverflow
+-Woverflow # (enabled by default)
 -Woverlength-strings
 -Woverloaded-virtual
 -Woverride-init
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
 -Wpedantic
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
 -Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
--Wreturn-local-addr
+-Wreturn-local-addr # (enabled by default)
 -Wreturn-type
 -Wselector
 -Wsequence-point
 -Wshadow
--Wshadow-ivar
--Wshift-count-negative
--Wshift-count-overflow
+-Wshadow-ivar # (enabled by default)
+-Wshift-count-negative # (enabled by default)
+-Wshift-count-overflow # (enabled by default)
 -Wsign-compare
 -Wsign-conversion
 -Wsign-promo
 -Wsized-deallocation
--Wsizeof-array-argument
+-Wsizeof-array-argument # (enabled by default)
 -Wsizeof-pointer-memaccess
 -Wstack-protector
 -Wstack-usage=
@@ -164,10 +164,10 @@
 -Wsuggest-final-types
 -Wsuggest-override
 -Wswitch
--Wswitch-bool
+-Wswitch-bool # (enabled by default)
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtraditional
@@ -190,15 +190,15 @@
 -Wunused-local-typedefs
 -Wunused-macros
 -Wunused-parameter
--Wunused-result
+-Wunused-result # (enabled by default)
 -Wunused-value
 -Wunused-variable
 -Wuseless-cast
--Wvarargs
+-Wvarargs # (enabled by default)
 -Wvariadic-macros
 -Wvector-operation-performance
--Wvirtual-move-assign
--Wvla
+-Wvirtual-move-assign # (enabled by default)
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/gcc/warnings-gcc-unique-6.txt
+++ b/gcc/warnings-gcc-unique-6.txt
@@ -8,21 +8,21 @@
 -Wabi=
 -Waddress
 -Waggregate-return
--Waggressive-loop-optimizations
+-Waggressive-loop-optimizations # (enabled by default)
 -Wall
 -Warray-bounds
 -Warray-bounds=
 -Wassign-intercept
--Wattributes
+-Wattributes # (enabled by default)
 -Wbad-function-cast
 -Wbool-compare
--Wbuiltin-macro-redefined
+-Wbuiltin-macro-redefined # (enabled by default)
 -Wc++-compat
 -Wc++0x-compat
 -Wc++11-compat
 -Wc++14-compat
--Wc90-c99-compat
--Wc99-c11-compat
+-Wc90-c99-compat # (enabled by default)
+-Wc99-c11-compat # (enabled by default)
 -Wcast-align
 -Wcast-qual
 -Wchar-subscripts
@@ -32,27 +32,27 @@
 -Wcomments
 -Wconditionally-supported
 -Wconversion
--Wconversion-null
--Wcoverage-mismatch
--Wcpp
+-Wconversion-null # (enabled by default)
+-Wcoverage-mismatch # (enabled by default)
+-Wcpp # (enabled by default)
 -Wctor-dtor-privacy
 -Wdate-time
--Wdeclaration-after-statement
--Wdelete-incomplete
+-Wdeclaration-after-statement # (enabled by default)
+-Wdelete-incomplete # (enabled by default)
 -Wdelete-non-virtual-dtor
--Wdeprecated
--Wdeprecated-declarations
--Wdesignated-init
+-Wdeprecated # (enabled by default)
+-Wdeprecated-declarations # (enabled by default)
+-Wdesignated-init # (enabled by default)
 -Wdisabled-optimization
--Wdiscarded-array-qualifiers
--Wdiscarded-qualifiers
--Wdiv-by-zero
+-Wdiscarded-array-qualifiers # (enabled by default)
+-Wdiscarded-qualifiers # (enabled by default)
+-Wdiv-by-zero # (enabled by default)
 -Wdouble-promotion
 -Wduplicated-cond
 -Weffc++
 -Wempty-body
--Wendif-labels
--Wenum-compare
+-Wendif-labels # (enabled by default)
+-Wenum-compare # (enabled by default)
 -Werror-implicit-function-declaration
 -Wextra
 -Wfloat-conversion
@@ -68,32 +68,32 @@
 -Wformat=
 -Wframe-address
 -Wframe-larger-than=
--Wfree-nonheap-object
--Whsa
--Wignored-attributes
+-Wfree-nonheap-object # (enabled by default)
+-Whsa # (enabled by default)
+-Wignored-attributes # (enabled by default)
 -Wignored-qualifiers
 -Wimplicit
--Wimplicit-function-declaration
--Wimplicit-int
+-Wimplicit-function-declaration # (enabled by default)
+-Wimplicit-int # (enabled by default)
 -Wimport # DUMMY switch
--Wincompatible-pointer-types
--Winherited-variadic-ctor
+-Wincompatible-pointer-types # (enabled by default)
+-Winherited-variadic-ctor # (enabled by default)
 -Winit-self
 -Winline
--Wint-conversion
--Wint-to-pointer-cast
--Winvalid-memory-model
--Winvalid-offsetof
+-Wint-conversion # (enabled by default)
+-Wint-to-pointer-cast # (enabled by default)
+-Winvalid-memory-model # (enabled by default)
+-Winvalid-offsetof # (enabled by default)
 -Winvalid-pch
 -Wjump-misses-init
 -Wlarger-than-
 -Wlarger-than=
--Wliteral-suffix
+-Wliteral-suffix # (enabled by default)
 -Wlogical-not-parentheses
 -Wlogical-op
--Wlong-long
--Wlto-type-mismatch
--Wmain
+-Wlong-long # (enabled by default)
+-Wlto-type-mismatch # (enabled by default)
+-Wmain # (enabled by default)
 -Wmaybe-uninitialized
 -Wmemset-transposed-args
 -Wmisleading-indentation
@@ -109,60 +109,60 @@
 -Wmultichar
 -Wmultiple-inheritance
 -Wnamespaces
--Wnarrowing
+-Wnarrowing # (enabled by default)
 -Wnested-externs
 -Wnoexcept
--Wnon-template-friend
+-Wnon-template-friend # (enabled by default)
 -Wnon-virtual-dtor
 -Wnonnull
 -Wnonnull-compare
 -Wnormalized
 -Wnormalized=
 -Wnull-dereference
--Wodr
+-Wodr # (enabled by default)
 -Wold-style-cast
 -Wold-style-declaration
 -Wold-style-definition
 -Wopenmp-simd
--Woverflow
+-Woverflow # (enabled by default)
 -Woverlength-strings
 -Woverloaded-virtual
 -Woverride-init
--Woverride-init-side-effects
+-Woverride-init-side-effects # (enabled by default)
 -Wpacked
--Wpacked-bitfield-compat
+-Wpacked-bitfield-compat # (enabled by default)
 -Wpadded
 -Wparentheses
 -Wpedantic
 -Wplacement-new
 -Wplacement-new=
--Wpmf-conversions
+-Wpmf-conversions # (enabled by default)
 -Wpointer-arith
 -Wpointer-sign
--Wpointer-to-int-cast
--Wpragmas
--Wproperty-assign-default
--Wprotocol
--Wpsabi
+-Wpointer-to-int-cast # (enabled by default)
+-Wpragmas # (enabled by default)
+-Wproperty-assign-default # (enabled by default)
+-Wprotocol # (enabled by default)
+-Wpsabi # (enabled by default)
 -Wredundant-decls
 -Wreorder
--Wreturn-local-addr
+-Wreturn-local-addr # (enabled by default)
 -Wreturn-type
--Wscalar-storage-order
+-Wscalar-storage-order # (enabled by default)
 -Wselector
 -Wsequence-point
 -Wshadow
--Wshadow-ivar
--Wshift-count-negative
--Wshift-count-overflow
--Wshift-negative-value
+-Wshadow-ivar # (enabled by default)
+-Wshift-count-negative # (enabled by default)
+-Wshift-count-overflow # (enabled by default)
+-Wshift-negative-value # (enabled by default)
 -Wshift-overflow
 -Wshift-overflow=
 -Wsign-compare
 -Wsign-conversion
 -Wsign-promo
 -Wsized-deallocation
--Wsizeof-array-argument
+-Wsizeof-array-argument # (enabled by default)
 -Wsizeof-pointer-memaccess
 -Wstack-protector
 -Wstack-usage=
@@ -173,7 +173,7 @@
 -Wstrict-overflow=
 -Wstrict-prototypes
 -Wstrict-selector-match
--Wsubobject-linkage
+-Wsubobject-linkage # (enabled by default)
 -Wsuggest-attribute=const
 -Wsuggest-attribute=format
 -Wsuggest-attribute=noreturn
@@ -182,15 +182,15 @@
 -Wsuggest-final-types
 -Wsuggest-override
 -Wswitch
--Wswitch-bool
+-Wswitch-bool # (enabled by default)
 -Wswitch-default
 -Wswitch-enum
--Wsync-nand
+-Wsync-nand # (enabled by default)
 -Wsynth
 -Wsystem-headers
 -Wtautological-compare
 -Wtemplates
--Wterminate
+-Wterminate # (enabled by default)
 -Wtraditional
 -Wtraditional-conversion
 -Wtrampolines
@@ -213,16 +213,16 @@
 -Wunused-local-typedefs
 -Wunused-macros
 -Wunused-parameter
--Wunused-result
+-Wunused-result # (enabled by default)
 -Wunused-value
 -Wunused-variable
 -Wuseless-cast
--Wvarargs
+-Wvarargs # (enabled by default)
 -Wvariadic-macros
 -Wvector-operation-performance
 -Wvirtual-inheritance
--Wvirtual-move-assign
--Wvla
+-Wvirtual-move-assign # (enabled by default)
+-Wvla # (enabled by default)
 -Wvolatile-register-var
 -Wwrite-strings
 -Wzero-as-null-pointer-constant

--- a/parsers/parse-gcc-warning-options.py
+++ b/parsers/parse-gcc-warning-options.py
@@ -348,10 +348,25 @@ class DummyWarningListener(GccOptionsListener.GccOptionsListener):
             self.is_dummy = True
 
 
+def print_child_option(option_name, level):
+    print("# " + "  " * level, "-" + option_name)
+
+
+def print_default_options(defaults, references):
+    if len(defaults) == 0:
+        return
+
+    print("# enabled by default:")
+
+    for option_name in sorted(defaults):
+        print_child_option(option_name, 1)
+        print_enabled_options(references, option_name, 2)
+
+
 def print_enabled_options(references, option_name, level=1):
     for reference in sorted(
             references.get(option_name, []), key=lambda x: x.lower()):
-        print("# " + "  " * level, "-" + reference)
+        print_child_option(reference, level)
         if reference in references:
             print_enabled_options(references, reference, level + 1)
 
@@ -432,6 +447,10 @@ def create_defaults_text(defaults, switch_name):
 
 
 def print_warning_flags(args, references, parents, aliases, warnings, dummies, defaults):
+    if args.top_level:
+        # Print a group that has all enabled-by-default warnings together
+        print_default_options(warnings.intersection(defaults), references)
+
     for option_name in sorted(references.keys(), key=lambda x: x.lower()):
         option_aliases = aliases.get(option_name, [])
         if option_name not in warnings:
@@ -451,6 +470,8 @@ def print_warning_flags(args, references, parents, aliases, warnings, dummies, d
 
         if args.top_level:
             if option_name in aliases:
+                continue
+            if option_name in defaults:
                 continue
             if len(parents.get(option_name, set())) > 0:
                 continue


### PR DESCRIPTION
This patch series enhances the GCC options parser to indicate the options that are enabled by default, for the unique and top-level outputs. Having this information indicated within a diff makes it easier to see which options to consider enabling explicitly in a project.

The clang input doesn't appear to have anything corresponding.

A few questions came to mind during implementation -- comments on these or anything else are welcome.
- Should this change in output be enabled by a command line option?
- Do you see any problems or omissions in the heuristic used by DefaultsListener?
- Should the listeners be focused on individual properties and the combination moved from DefaultsListener to parse_options_file?